### PR TITLE
Add WhatsApp transactional notifications (opt‑in, logging, triggers, edge functions)

### DIFF
--- a/app/src/lib/services/order.service.js
+++ b/app/src/lib/services/order.service.js
@@ -10,8 +10,9 @@ export const OrderService = {
      * @param {string} orderData.customer_email
      * @param {string} orderData.customer_phone
      * @param {string} orderData.notes
+     * @param {boolean} orderData.whatsapp_opt_in
      */
-    async createOrder({ store_id, items, total, customer_email, customer_phone, notes, user_id }) {
+    async createOrder({ store_id, items, total, customer_email, customer_phone, notes, user_id, whatsapp_opt_in = false }) {
         if (!supabase) throw new Error('Supabase not configured');
 
         // Use RPC for atomic transaction of order + order_items
@@ -22,7 +23,8 @@ export const OrderService = {
             p_customer_email: customer_email,
             p_customer_phone: customer_phone,
             p_notes: notes,
-            p_user_id: user_id || null // Allow null for guest checkout
+            p_user_id: user_id || null, // Allow null for guest checkout
+            p_whatsapp_opt_in: whatsapp_opt_in
         });
 
         if (error) throw error;

--- a/app/src/pages/attendee/Checkout.jsx
+++ b/app/src/pages/attendee/Checkout.jsx
@@ -19,6 +19,7 @@ export default function Checkout() {
     const [email, setEmail] = useState('');
     const [phone, setPhone] = useState('');
     const [notes, setNotes] = useState('');
+    const [whatsappOptIn, setWhatsappOptIn] = useState(false);
     const [processing, setProcessing] = useState(false);
 
     const [tipAmount, setTipAmount] = useState(0);
@@ -85,6 +86,12 @@ export default function Checkout() {
                 return;
             }
 
+            if (!whatsappOptIn) {
+                addToast('Please confirm WhatsApp opt-in to continue checkout.', 'error');
+                setProcessing(false);
+                return;
+            }
+
             // 2. Pre-check Vendor Payment Readiness
             if (vendor && !vendor.stripe_onboarding_complete) {
                 addToast('This vendor is not yet set up to receive payments. Their bank account is still being connected.', 'error');
@@ -98,6 +105,7 @@ export default function Checkout() {
                 total: total,
                 customer_email: email || user?.email,
                 customer_phone: phone,
+                whatsapp_opt_in: whatsappOptIn,
                 notes: notes,
                 user_id: user?.id || null // Support guest checkout
             });
@@ -245,6 +253,24 @@ export default function Checkout() {
                             placeholder="Allergies, instructions, etc."
                             style={{ width: '100%', padding: '12px', borderRadius: '8px', border: '1px solid var(--stroke)', background: 'var(--card)', minHeight: '80px' }}
                         />
+                    </div>
+
+                    <div className="card" style={{ marginBottom: '24px' }}>
+                        <h3 style={{ marginBottom: '8px' }}>WhatsApp Updates</h3>
+                        <p className="text-muted" style={{ fontSize: '14px', marginBottom: '16px' }}>
+                            Purely transactional. No marketing. Standard rates apply.
+                        </p>
+
+                        <label style={{ display: 'flex', alignItems: 'flex-start', gap: '10px', cursor: 'pointer' }}>
+                            <input
+                                type="checkbox"
+                                checked={whatsappOptIn}
+                                onChange={(e) => setWhatsappOptIn(e.target.checked)}
+                                style={{ marginTop: '2px' }}
+                                required
+                            />
+                            <span>Opt-in to receiving order updates via WhatsApp.</span>
+                        </label>
                     </div>
 
                     <button

--- a/app/src/pages/attendee/OrderTracker.jsx
+++ b/app/src/pages/attendee/OrderTracker.jsx
@@ -179,6 +179,25 @@ export default function OrderTracker() {
                         {vendor.pickup_location && (
                             <p className="text-accent">📍 Pickup at: {vendor.pickup_location}</p>
                         )}
+
+                        <div style={{ marginTop: '12px' }}>
+                            <span
+                                style={{
+                                    display: 'inline-flex',
+                                    alignItems: 'center',
+                                    gap: '6px',
+                                    padding: '6px 10px',
+                                    borderRadius: '999px',
+                                    fontSize: '12px',
+                                    fontWeight: '700',
+                                    background: order.whatsapp_opt_in ? 'rgba(16, 185, 129, 0.14)' : 'rgba(107, 114, 128, 0.12)',
+                                    color: order.whatsapp_opt_in ? '#047857' : '#6b7280',
+                                    border: `1px solid ${order.whatsapp_opt_in ? 'rgba(16, 185, 129, 0.35)' : 'rgba(107, 114, 128, 0.25)'}`,
+                                }}
+                            >
+                                {order.whatsapp_opt_in ? '📱 WhatsApp updates active' : '📱 WhatsApp updates inactive'}
+                            </span>
+                        </div>
                     </div>
                 )}
 

--- a/supabase/functions/whatsapp-notify/index.ts
+++ b/supabase/functions/whatsapp-notify/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { logger } from "../_shared/logger.ts"
 
 const log = logger('whatsapp-notify')
@@ -6,10 +7,30 @@ const log = logger('whatsapp-notify')
 const TWILIO_ACCOUNT_SID = Deno.env.get('TWILIO_ACCOUNT_SID')
 const TWILIO_AUTH_TOKEN = Deno.env.get('TWILIO_AUTH_TOKEN')
 const TWILIO_WHATSAPP_NUMBER = Deno.env.get('TWILIO_WHATSAPP_NUMBER') // e.g., +14155238886
+const TWILIO_TEMPLATE_ORDER_CONFIRMATION = Deno.env.get('TWILIO_TEMPLATE_ORDER_CONFIRMATION')
+const TWILIO_TEMPLATE_ORDER_PREPARING = Deno.env.get('TWILIO_TEMPLATE_ORDER_PREPARING')
+const TWILIO_TEMPLATE_READY_FOR_COLLECTION = Deno.env.get('TWILIO_TEMPLATE_READY_FOR_COLLECTION')
+const TWILIO_TEMPLATE_ORDER_CANCELLED = Deno.env.get('TWILIO_TEMPLATE_ORDER_CANCELLED')
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+
+const templateMap: Record<string, string | undefined> = {
+  paid: TWILIO_TEMPLATE_ORDER_CONFIRMATION,
+  preparing: TWILIO_TEMPLATE_ORDER_PREPARING,
+  ready: TWILIO_TEMPLATE_READY_FOR_COLLECTION,
+  cancelled: TWILIO_TEMPLATE_ORDER_CANCELLED,
+}
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const normalizePhone = (customerPhone: string) => {
+  const trimmed = customerPhone.trim()
+  if (trimmed.startsWith('+')) return trimmed
+  return `+44${trimmed.startsWith('0') ? trimmed.slice(1) : trimmed}`
 }
 
 serve(async (req) => {
@@ -18,62 +39,85 @@ serve(async (req) => {
   }
 
   try {
+    if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+      throw new Error('Missing Supabase service role environment variables')
+    }
+
+    if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN || !TWILIO_WHATSAPP_NUMBER) {
+      throw new Error('Missing Twilio WhatsApp environment variables')
+    }
+
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
     const payload = await req.json()
     const { record, old_record, type } = payload
 
-    // Only process updates to the 'status' column
     if (type !== 'UPDATE' || record.status === old_record.status) {
       return new Response(JSON.stringify({ skipped: true, reason: 'No status change' }), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       })
     }
 
-    const { status, customer_phone, order_number, id } = record
-    
-    if (!customer_phone) {
-      log.warn(`No phone number for order ${id}`, { order_number })
+    if (!record.whatsapp_opt_in) {
+      return new Response(JSON.stringify({ skipped: true, reason: 'WhatsApp opt-in disabled' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const orderId = record.id as string
+
+    const { data: order, error: orderError } = await supabase
+      .from('orders')
+      .select('id, order_number, status, customer_phone, total, stores(name)')
+      .eq('id', orderId)
+      .single()
+
+    if (orderError || !order) {
+      throw new Error(`Order lookup failed: ${orderError?.message || 'missing order'}`)
+    }
+
+    if (!order.customer_phone) {
+      log.warn(`No phone number for order ${order.id}`, { order_number: order.order_number })
       return new Response(JSON.stringify({ skipped: true, reason: 'No phone number' }), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       })
     }
 
-    // Define message templates
-    let message = ''
-    switch (status) {
-      case 'paid':
-        message = `✅ SKIIP: Order ${order_number} confirmed! We'll notify you when it's being prepared.`
-        break
-      case 'preparing':
-        message = `👨‍🍳 SKIIP: Your order ${order_number} is now being prepared!`
-        break
-      case 'ready':
-        message = `⚡ SKIIP: Your order ${order_number} is READY for pickup! Please head to the vendor area.`
-        break
-      case 'cancelled':
-        message = `❌ SKIIP: Order ${order_number} has been cancelled. Please check the app for details.`
-        break
-      default:
-        return new Response(JSON.stringify({ skipped: true, reason: 'Unmapped status' }), {
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        })
+    const templateSid = templateMap[order.status]
+    if (!templateSid) {
+      return new Response(JSON.stringify({ skipped: true, reason: 'No mapped template' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
     }
 
-    log.info(`Sending WhatsApp to ${customer_phone} for status: ${status}`)
+    const { data: queuedLog, error: queuedError } = await supabase
+      .from('notification_logs')
+      .insert({
+        order_id: order.id,
+        status: 'queued',
+      })
+      .select('id')
+      .single()
 
-    // Format phone number for WhatsApp (must start with + and include country code)
-    let formattedPhone = customer_phone.trim()
-    if (!formattedPhone.startsWith('+')) {
-      // Default to UK if missing + (simple heuristic for pilot)
-      formattedPhone = `+44${formattedPhone.startsWith('0') ? formattedPhone.slice(1) : formattedPhone}`
+    if (queuedError || !queuedLog) {
+      throw new Error(`Failed to persist queued notification log: ${queuedError?.message || 'unknown error'}`)
     }
 
+    const formattedPhone = normalizePhone(order.customer_phone)
     const twilioUrl = `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json`
     const auth = btoa(`${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}`)
+
+    const contentVariables = {
+      1: order.order_number,
+      2: order.stores?.name || 'SKIIP vendor',
+      3: Number(order.total || 0).toFixed(2),
+    }
 
     const formData = new URLSearchParams()
     formData.append('To', `whatsapp:${formattedPhone}`)
     formData.append('From', `whatsapp:${TWILIO_WHATSAPP_NUMBER}`)
-    formData.append('Body', message)
+    formData.append('ContentSid', templateSid)
+    formData.append('ContentVariables', JSON.stringify(contentVariables))
+    formData.append('StatusCallback', `${SUPABASE_URL}/functions/v1/whatsapp-status-webhook`)
 
     const response = await fetch(twilioUrl, {
       method: 'POST',
@@ -87,12 +131,29 @@ serve(async (req) => {
     const result = await response.json()
 
     if (!response.ok) {
+      await supabase
+        .from('notification_logs')
+        .update({
+          status: 'failed',
+          error_message: result.message || response.statusText,
+        })
+        .eq('id', queuedLog.id)
+
       throw new Error(`Twilio API error: ${result.message || response.statusText}`)
     }
 
-    log.info(`WhatsApp sent successfully to ${customer_phone}`, { sid: result.sid })
+    await supabase
+      .from('notification_logs')
+      .update({
+        message_sid: result.sid,
+        status: 'sent',
+        error_message: null,
+      })
+      .eq('id', queuedLog.id)
 
-    return new Response(JSON.stringify({ success: true, sid: result.sid }), {
+    log.info(`WhatsApp sent successfully to ${formattedPhone}`, { sid: result.sid, orderId: order.id })
+
+    return new Response(JSON.stringify({ success: true, sid: result.sid, logId: queuedLog.id }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     })
   } catch (error) {

--- a/supabase/functions/whatsapp-status-webhook/index.ts
+++ b/supabase/functions/whatsapp-status-webhook/index.ts
@@ -1,0 +1,104 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { logger } from "../_shared/logger.ts"
+
+const log = logger('whatsapp-status-webhook')
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+const TWILIO_WEBHOOK_TOKEN = Deno.env.get('TWILIO_WEBHOOK_TOKEN')
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const mapStatus = (providerStatus: string | null) => {
+  switch ((providerStatus || '').toLowerCase()) {
+    case 'queued':
+    case 'accepted':
+      return 'queued'
+    case 'sent':
+      return 'sent'
+    case 'delivered':
+      return 'delivered'
+    case 'read':
+      return 'read'
+    case 'failed':
+    case 'undelivered':
+      return 'failed'
+    default:
+      return null
+  }
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405, headers: corsHeaders })
+  }
+
+  try {
+    if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+      throw new Error('Missing Supabase service role environment variables')
+    }
+
+    const authHeader = req.headers.get('authorization')
+    if (TWILIO_WEBHOOK_TOKEN && authHeader !== `Bearer ${TWILIO_WEBHOOK_TOKEN}`) {
+      return new Response(JSON.stringify({ error: 'unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const body = await req.text()
+    const params = new URLSearchParams(body)
+
+    const messageSid = params.get('MessageSid')
+    const providerStatus = params.get('MessageStatus')
+    const errorMessage = params.get('ErrorMessage')
+
+    if (!messageSid || !providerStatus) {
+      return new Response(JSON.stringify({ skipped: true, reason: 'Missing MessageSid or MessageStatus' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const status = mapStatus(providerStatus)
+    if (!status) {
+      return new Response(JSON.stringify({ skipped: true, reason: `Unmapped status: ${providerStatus}` }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+    const { error: updateError } = await supabase
+      .from('notification_logs')
+      .update({
+        status,
+        error_message: status === 'failed' ? errorMessage || 'Unknown delivery failure' : null,
+      })
+      .eq('message_sid', messageSid)
+
+    if (updateError) {
+      throw new Error(`Failed to update log status: ${updateError.message}`)
+    }
+
+    log.info('WhatsApp delivery status updated', { messageSid, providerStatus, status })
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  } catch (error) {
+    log.error('Failed to process webhook', { error: error.message, stack: error.stack })
+
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  }
+})

--- a/supabase/migrations/20260410000000_whatsapp_notifications.sql
+++ b/supabase/migrations/20260410000000_whatsapp_notifications.sql
@@ -1,0 +1,174 @@
+-- ============================================================
+-- Migration: WhatsApp transactional notifications
+-- Adds opt-in field, logging table, and status-change trigger
+-- ============================================================
+
+-- Extension required for asynchronous HTTP from Postgres triggers.
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+ALTER TABLE public.orders
+ADD COLUMN IF NOT EXISTS whatsapp_opt_in BOOLEAN NOT NULL DEFAULT false;
+
+CREATE TABLE IF NOT EXISTS public.notification_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    order_id UUID NOT NULL REFERENCES public.orders(id) ON DELETE CASCADE,
+    message_sid TEXT,
+    status TEXT NOT NULL CHECK (status IN ('queued', 'sent', 'delivered', 'read', 'failed')),
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_logs_message_sid
+    ON public.notification_logs(message_sid)
+    WHERE message_sid IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_notification_logs_order_id_created_at
+    ON public.notification_logs(order_id, created_at DESC);
+
+ALTER TABLE public.notification_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Sellers can view notification logs for store orders" ON public.notification_logs;
+CREATE POLICY "Sellers can view notification logs for store orders"
+ON public.notification_logs
+FOR SELECT
+USING (
+    EXISTS (
+        SELECT 1
+        FROM public.orders o
+        JOIN public.stores s ON s.id = o.store_id
+        WHERE o.id = notification_logs.order_id
+          AND s.user_id = auth.uid()
+    )
+);
+
+DROP POLICY IF EXISTS "Admins can view notification logs" ON public.notification_logs;
+CREATE POLICY "Admins can view notification logs"
+ON public.notification_logs
+FOR SELECT
+USING (public.is_admin());
+
+DROP POLICY IF EXISTS "Service role can manage notification logs" ON public.notification_logs;
+CREATE POLICY "Service role can manage notification logs"
+ON public.notification_logs
+FOR ALL
+USING (auth.role() = 'service_role')
+WITH CHECK (auth.role() = 'service_role');
+
+CREATE OR REPLACE FUNCTION public.create_order_v1(
+    p_store_id UUID,
+    p_items JSONB,
+    p_total NUMERIC,
+    p_customer_email TEXT,
+    p_customer_phone TEXT,
+    p_notes TEXT,
+    p_user_id UUID DEFAULT NULL,
+    p_whatsapp_opt_in BOOLEAN DEFAULT false
+) RETURNS public.orders AS $$
+DECLARE
+    v_order public.orders;
+    v_item JSONB;
+    v_order_number TEXT;
+BEGIN
+    v_order_number := 'ORD-' || to_char(now(), 'YYYYMMDD') || '-' || LPAD(floor(random() * 10000)::text, 4, '0');
+
+    INSERT INTO public.orders (
+        store_id,
+        user_id,
+        order_number,
+        status,
+        total,
+        subtotal,
+        customer_email,
+        customer_phone,
+        notes,
+        whatsapp_opt_in
+    ) VALUES (
+        p_store_id,
+        p_user_id,
+        v_order_number,
+        'pending',
+        p_total,
+        p_total,
+        p_customer_email,
+        p_customer_phone,
+        p_notes,
+        p_whatsapp_opt_in
+    ) RETURNING * INTO v_order;
+
+    FOR v_item IN SELECT * FROM jsonb_array_elements(p_items)
+    LOOP
+        INSERT INTO public.order_items (
+            order_id,
+            product_id,
+            quantity,
+            price,
+            total,
+            product_snapshot
+        ) VALUES (
+            v_order.id,
+            (v_item->>'id')::UUID,
+            (v_item->>'quantity')::INTEGER,
+            (v_item->>'price')::NUMERIC,
+            ((v_item->>'price')::NUMERIC * (v_item->>'quantity')::INTEGER),
+            jsonb_build_object('name', v_item->>'name', 'price', v_item->>'price')
+        );
+    END LOOP;
+
+    RETURN v_order;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION public.notify_whatsapp_on_order_status_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    request_body JSONB;
+BEGIN
+    IF NEW.whatsapp_opt_in IS NOT TRUE THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.status IS NOT DISTINCT FROM OLD.status THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.status NOT IN ('paid', 'preparing', 'ready', 'cancelled') THEN
+        RETURN NEW;
+    END IF;
+
+    request_body := jsonb_build_object(
+        'type', TG_OP,
+        'table', TG_TABLE_NAME,
+        'schema', TG_TABLE_SCHEMA,
+        'record', to_jsonb(NEW),
+        'old_record', to_jsonb(OLD)
+    );
+
+    PERFORM net.http_post(
+        url := concat(current_setting('app.settings.supabase_url'), '/functions/v1/whatsapp-notify'),
+        headers := jsonb_build_object(
+            'Content-Type', 'application/json',
+            'Authorization', concat('Bearer ', current_setting('app.settings.service_role_key'))
+        ),
+        body := request_body
+    );
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS orders_whatsapp_notify_trigger ON public.orders;
+CREATE TRIGGER orders_whatsapp_notify_trigger
+AFTER UPDATE OF status ON public.orders
+FOR EACH ROW
+EXECUTE FUNCTION public.notify_whatsapp_on_order_status_change();
+
+DROP TRIGGER IF EXISTS update_notification_logs_modtime ON public.notification_logs;
+CREATE TRIGGER update_notification_logs_modtime
+BEFORE UPDATE ON public.notification_logs
+FOR EACH ROW
+EXECUTE PROCEDURE public.update_updated_at_column();


### PR DESCRIPTION
### Motivation
- Add a compliant, opt‑in WhatsApp order notification pipeline so customers can receive transactional updates (payment, preparing, ready, cancelled) while capturing consent and delivery state. 
- Provide vendor visibility into message delivery by persisting notification logs and statuses for operational support and resilience. 
- Implementation used the `supabase-postgres-best-practices` skill to guide schema/index/trigger and RLS design choices. 

### Description
- UI and client: add a mandatory (not preselected) WhatsApp opt‑in checkbox on the checkout page and enforce consent before creating an order, and surface `whatsapp_opt_in` on the order tracker as a status badge. 
- API/client service: extend `OrderService.createOrder` to pass `p_whatsapp_opt_in` to the `create_order_v1` RPC so consent is stored with the order. 
- Database/migration: add `orders.whatsapp_opt_in`, create `notification_logs` (with indexes and RLS policies), update `create_order_v1` to accept the opt‑in flag, and add a trigger that calls the `whatsapp-notify` Edge Function via `pg_net` when relevant status changes occur. 
- Edge functions: replace the simple send flow with a template-driven `whatsapp-notify` function that looks up order/store data, inserts a `queued` log row, sends via Twilio Content Template SIDs, and updates logs to `sent`/`failed`; add `whatsapp-status-webhook` to map provider callbacks into `notification_logs` (`queued`, `sent`, `delivered`, `read`, `failed`). 
- Environment variables: new env vars are required for Twilio templates and webhooks e.g. `TWILIO_TEMPLATE_ORDER_CONFIRMATION`, `TWILIO_TEMPLATE_ORDER_PREPARING`, `TWILIO_TEMPLATE_READY_FOR_COLLECTION`, `TWILIO_TEMPLATE_ORDER_CANCELLED`, and `TWILIO_WEBHOOK_TOKEN` (optional). 

### Testing
- Built the frontend assets successfully with `npm --prefix app run build`, which completed without errors. 
- No additional automated tests were run in this rollout; migration and runtime behavior require applying the new SQL migration and configuring environment variables in a staging environment for end‑to‑end verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92a2734ac832983e99655b46a4cb6)