### PR TITLE
feat(notifications): migrate WhatsApp to Meta Cloud API and refine email scoping

### DIFF
--- a/app/test-results-alt/.last-run.json
+++ b/app/test-results-alt/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -143,6 +143,7 @@ These items matter, but they do not block a safe first launch if the Priority 1 
 - Add Apple SSO.
 - Decide whether passwordless or magic-link flows are desirable after launch.
 - Revisit whether email confirmation should return once SMTP and support processes are stronger.
+- Add a buyer settings/profile page that stores default checkout details such as country, email, and phone number, then reuse that data at checkout and for phone normalization instead of relying on a single deployment default.
 
 ### Notification Strategy
 

--- a/supabase/functions/_shared/notifications.ts
+++ b/supabase/functions/_shared/notifications.ts
@@ -9,6 +9,8 @@ type NotificationEvent =
   | 'order_cancelled'
   | 'order_refunded'
 
+const EMAIL_EVENTS: NotificationEvent[] = ['order_paid']
+
 interface NotificationContext {
   supabase: any
   orderId: string
@@ -59,23 +61,82 @@ const EVENT_COPY: Record<NotificationEvent, { subject: string; headline: string;
 }
 
 const WHATSAPP_TEMPLATE_MAP: Record<NotificationEvent, string | undefined> = {
-  order_paid: Deno.env.get('TWILIO_TEMPLATE_ORDER_CONFIRMATION'),
-  order_preparing: Deno.env.get('TWILIO_TEMPLATE_ORDER_PREPARING'),
-  order_ready: Deno.env.get('TWILIO_TEMPLATE_READY_FOR_COLLECTION'),
-  order_cancelled: Deno.env.get('TWILIO_TEMPLATE_ORDER_CANCELLED'),
-  order_refunded: Deno.env.get('TWILIO_TEMPLATE_ORDER_REFUNDED'),
+  order_paid: Deno.env.get('META_TEMPLATE_ORDER_PAID'),
+  order_preparing: Deno.env.get('META_TEMPLATE_ORDER_PREPARING'),
+  order_ready: Deno.env.get('META_TEMPLATE_ORDER_READY'),
+  order_cancelled: Deno.env.get('META_TEMPLATE_ORDER_CANCELLED'),
+  order_refunded: Deno.env.get('META_TEMPLATE_ORDER_REFUNDED'),
+}
+
+function getDefaultCountryCode() {
+  const configuredCountryCode = (Deno.env.get('WHATSAPP_DEFAULT_COUNTRY_CODE') || '44')
+    .trim()
+    .replace(/^\+/, '')
+
+  if (!/^\d{1,3}$/.test(configuredCountryCode)) {
+    log.error('Invalid WhatsApp default country code', {
+      configuredCountryCode,
+      reason: 'invalid_default_country_code',
+    })
+    return null
+  }
+
+  return configuredCountryCode
 }
 
 function normalizePhone(customerPhone: string) {
-  const trimmed = customerPhone.trim()
-  if (trimmed.startsWith('+')) {
-    return trimmed
+  const stripped = customerPhone.trim().replace(/[\s\-()]/g, '')
+  const hasExplicitCountryCode = stripped.startsWith('+')
+  const defaultCountryCode = getDefaultCountryCode()
+
+  if (!defaultCountryCode) {
+    return null
   }
-  return `+44${trimmed.startsWith('0') ? trimmed.slice(1) : trimmed}`
+
+  let normalized = hasExplicitCountryCode ? stripped.slice(1) : stripped
+
+  if (!normalized) {
+    log.error('Invalid WhatsApp phone number', { customerPhone, normalized, reason: 'non_digit_characters' })
+    return null
+  }
+
+  if (!hasExplicitCountryCode) {
+    if (normalized.startsWith('0')) {
+      normalized = `${defaultCountryCode}${normalized.slice(1)}`
+    } else if (!normalized.startsWith(defaultCountryCode)) {
+      log.error('Invalid WhatsApp phone number', {
+        customerPhone,
+        normalized,
+        defaultCountryCode,
+        reason: 'missing_explicit_or_default_country_code',
+      })
+      return null
+    }
+  }
+
+  if (/\D/.test(normalized)) {
+    log.error('Invalid WhatsApp phone number', { customerPhone, normalized, reason: 'non_digit_characters' })
+    return null
+  }
+
+  if (normalized.length < 8 || normalized.length > 15) {
+    log.error('Invalid WhatsApp phone number', { customerPhone, normalized, reason: 'invalid_length' })
+    return null
+  }
+
+  return normalized
 }
 
 function formatMoney(value: number | string | null | undefined) {
   return Number(value || 0).toFixed(2)
+}
+
+function getWhatsAppAmount(order: OrderRecord, eventType: NotificationEvent) {
+  return formatMoney(eventType === 'order_refunded' ? order.refund_amount || order.total : order.total)
+}
+
+function getMetaErrorMessage(payload: any, fallback: string) {
+  return payload?.error?.message || payload?.message || fallback
 }
 
 function buildEmailBody(order: OrderRecord, eventType: NotificationEvent) {
@@ -123,6 +184,10 @@ async function insertNotificationLog(
 }
 
 async function sendEmailNotification(supabase: any, order: OrderRecord, eventType: NotificationEvent) {
+  if (!EMAIL_EVENTS.includes(eventType)) {
+    return { skipped: true }
+  }
+
   const resendApiKey = Deno.env.get('RESEND_API_KEY')
   const fromEmail = Deno.env.get('NOTIFICATION_FROM_EMAIL')
 
@@ -183,22 +248,22 @@ async function sendEmailNotification(supabase: any, order: OrderRecord, eventTyp
 }
 
 async function sendWhatsAppNotification(supabase: any, order: OrderRecord, eventType: NotificationEvent) {
-  const twilioAccountSid = Deno.env.get('TWILIO_ACCOUNT_SID')
-  const twilioAuthToken = Deno.env.get('TWILIO_AUTH_TOKEN')
-  const twilioWhatsappNumber = Deno.env.get('TWILIO_WHATSAPP_NUMBER')
-  const webhookToken = Deno.env.get('TWILIO_WEBHOOK_TOKEN')
-  const supabaseUrl = Deno.env.get('SUPABASE_URL')
-  const templateSid = WHATSAPP_TEMPLATE_MAP[eventType]
+  const accessToken = Deno.env.get('WHATSAPP_ACCESS_TOKEN')
+  const phoneNumberId = Deno.env.get('WHATSAPP_PHONE_NUMBER_ID')
+  const templateName = WHATSAPP_TEMPLATE_MAP[eventType]?.trim()
 
   if (
-    !twilioAccountSid ||
-    !twilioAuthToken ||
-    !twilioWhatsappNumber ||
-    !templateSid ||
-    !supabaseUrl ||
+    !accessToken ||
+    !phoneNumberId ||
+    !templateName ||
     !order.whatsapp_opt_in ||
     !order.customer_phone
   ) {
+    return { skipped: true }
+  }
+
+  const normalizedPhone = normalizePhone(order.customer_phone)
+  if (!normalizedPhone) {
     return { skipped: true }
   }
 
@@ -206,58 +271,88 @@ async function sendWhatsAppNotification(supabase: any, order: OrderRecord, event
     order_id: order.id,
     channel: 'whatsapp',
     event_type: eventType,
-    provider: 'twilio',
+    provider: 'meta',
     recipient: order.customer_phone,
     status: 'queued',
   })
 
-  const callbackBase = `${supabaseUrl}/functions/v1/whatsapp-status-webhook`
-  const callbackUrl = webhookToken
-    ? `${callbackBase}?token=${encodeURIComponent(webhookToken)}`
-    : callbackBase
-
-  const formData = new URLSearchParams()
-  formData.append('To', `whatsapp:${normalizePhone(order.customer_phone)}`)
-  formData.append('From', `whatsapp:${twilioWhatsappNumber}`)
-  formData.append('ContentSid', templateSid)
-  formData.append(
-    'ContentVariables',
-    JSON.stringify({
-      1: order.order_number,
-      2: order.stores?.name || 'SKIIP vendor',
-      3: formatMoney(eventType === 'order_refunded' ? order.refund_amount || order.total : order.total),
-    }),
-  )
-  formData.append('StatusCallback', callbackUrl)
-
-  const response = await fetch(`https://api.twilio.com/2010-04-01/Accounts/${twilioAccountSid}/Messages.json`, {
+  const response = await fetch(`https://graph.facebook.com/v19.0/${phoneNumberId}/messages`, {
     method: 'POST',
     headers: {
-      Authorization: `Basic ${btoa(`${twilioAccountSid}:${twilioAuthToken}`)}`,
-      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
     },
-    body: formData.toString(),
+    body: JSON.stringify({
+      messaging_product: 'whatsapp',
+      to: normalizedPhone,
+      type: 'template',
+      template: {
+        name: templateName,
+        language: { code: 'en' },
+        components: [
+          {
+            type: 'body',
+            parameters: [
+              { type: 'text', text: order.order_number },
+              { type: 'text', text: order.stores?.name || 'SKIIP vendor' },
+              { type: 'text', text: getWhatsAppAmount(order, eventType) },
+            ],
+          },
+        ],
+      },
+    }),
   })
 
   const payload = await response.json().catch(() => ({}))
   if (!response.ok) {
+    const errorMessage = getMetaErrorMessage(payload, response.statusText)
+
+    log.error('Meta WhatsApp API error', {
+      orderId: order.id,
+      eventType,
+      status: response.status,
+      payload,
+    })
+
     await supabase
       .from('notification_logs')
       .update({
         status: 'failed',
-        error_message: payload?.message || response.statusText,
+        error_message: errorMessage,
         metadata: payload || {},
       })
       .eq('id', logId)
 
-    throw new Error(`Twilio API error: ${payload?.message || response.statusText}`)
+    throw new Error(`Meta WhatsApp API error: ${errorMessage}`)
+  }
+
+  const messageSid = payload?.messages?.[0]?.id
+  if (!messageSid) {
+    const errorMessage = 'Meta WhatsApp API response missing messages[0].id'
+
+    log.error(errorMessage, {
+      orderId: order.id,
+      eventType,
+      payload,
+    })
+
+    await supabase
+      .from('notification_logs')
+      .update({
+        status: 'failed',
+        error_message: errorMessage,
+        metadata: payload || {},
+      })
+      .eq('id', logId)
+
+    throw new Error(errorMessage)
   }
 
   await supabase
     .from('notification_logs')
     .update({
       status: 'sent',
-      message_sid: payload?.sid || null,
+      message_sid: messageSid,
       metadata: payload || {},
       error_message: null,
     })

--- a/supabase/functions/whatsapp-notify/index.ts
+++ b/supabase/functions/whatsapp-notify/index.ts
@@ -4,6 +4,8 @@ import { buildCorsHeaders, jsonResponse } from "../_shared/http.ts"
 import { createServiceClient } from "../_shared/service.ts"
 import { sendTransactionalNotifications } from "../_shared/notifications.ts"
 
+// This bridge remains because the repo still contains deployment and database-trigger
+// dependencies for the route, and SQL cleanup is intentionally out of scope here.
 const log = logger('whatsapp-notify')
 
 const EVENT_MAP: Record<string, 'order_paid' | 'order_preparing' | 'order_ready' | 'order_cancelled' | 'order_refunded'> = {

--- a/supabase/functions/whatsapp-status-webhook/index.ts
+++ b/supabase/functions/whatsapp-status-webhook/index.ts
@@ -3,21 +3,15 @@ import { logger } from "../_shared/logger.ts"
 import { createServiceClient } from "../_shared/service.ts"
 
 const log = logger('whatsapp-status-webhook')
-
-const SUPABASE_URL = Deno.env.get('SUPABASE_URL')
-const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
-const TWILIO_WEBHOOK_TOKEN = Deno.env.get('TWILIO_WEBHOOK_TOKEN')
+const encoder = new TextEncoder()
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-hub-signature-256',
 }
 
 const mapStatus = (providerStatus: string | null) => {
   switch ((providerStatus || '').toLowerCase()) {
-    case 'queued':
-    case 'accepted':
-      return 'queued'
     case 'sent':
       return 'sent'
     case 'delivered':
@@ -25,11 +19,53 @@ const mapStatus = (providerStatus: string | null) => {
     case 'read':
       return 'read'
     case 'failed':
-    case 'undelivered':
       return 'failed'
     default:
       return null
   }
+}
+
+function toHex(buffer: ArrayBuffer) {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+async function computeMetaSignature(rawBody: string, secret: string) {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(rawBody))
+  return `sha256=${toHex(signature)}`
+}
+
+function safeCompare(left: string, right: string) {
+  if (left.length !== right.length) {
+    return false
+  }
+
+  let mismatch = 0
+  for (let i = 0; i < left.length; i += 1) {
+    mismatch |= left.charCodeAt(i) ^ right.charCodeAt(i)
+  }
+
+  return mismatch === 0
+}
+
+function getMetaStatusErrorMessage(errors: any[] | undefined) {
+  if (!errors?.length) {
+    return 'Unknown delivery failure'
+  }
+
+  return errors.find((error) => typeof error?.message === 'string')?.message
+    || errors.find((error) => typeof error?.title === 'string')?.title
+    || errors.find((error) => typeof error?.error_data?.details === 'string')?.error_data?.details
+    || 'Unknown delivery failure'
 }
 
 serve(async (req) => {
@@ -37,68 +73,94 @@ serve(async (req) => {
     return new Response('ok', { headers: corsHeaders })
   }
 
+  if (req.method === 'GET') {
+    const url = new URL(req.url)
+    const mode = url.searchParams.get('hub.mode')
+    const verifyToken = url.searchParams.get('hub.verify_token')
+    const challenge = url.searchParams.get('hub.challenge')
+    const expectedVerifyToken = Deno.env.get('META_WEBHOOK_VERIFY_TOKEN')
+
+    if (mode === 'subscribe' && verifyToken && expectedVerifyToken && verifyToken === expectedVerifyToken && challenge) {
+      return new Response(challenge, {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'text/plain' },
+      })
+    }
+
+    return new Response('Forbidden', { status: 403, headers: corsHeaders })
+  }
+
   if (req.method !== 'POST') {
     return new Response('Method not allowed', { status: 405, headers: corsHeaders })
   }
 
   try {
-    if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
-      throw new Error('Missing Supabase service role environment variables')
+    const rawBody = await req.text()
+    const signatureHeader = req.headers.get('x-hub-signature-256')
+    const metaAppSecret = Deno.env.get('META_APP_SECRET')
+
+    if (metaAppSecret) {
+      const expectedSignature = await computeMetaSignature(rawBody, metaAppSecret)
+      if (!signatureHeader || !safeCompare(signatureHeader, expectedSignature)) {
+        return new Response(JSON.stringify({ error: 'unauthorized' }), {
+          status: 401,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        })
+      }
+    } else {
+      log.warn('META_APP_SECRET is not configured; skipping Meta webhook signature verification')
     }
 
-    const authHeader = req.headers.get('authorization')
-    const url = new URL(req.url)
-    const queryToken = url.searchParams.get('token')
-    const headerMatches = authHeader === `Bearer ${TWILIO_WEBHOOK_TOKEN}`
-    const queryMatches = queryToken === TWILIO_WEBHOOK_TOKEN
-    if (TWILIO_WEBHOOK_TOKEN && !headerMatches && !queryMatches) {
-      return new Response(JSON.stringify({ error: 'unauthorized' }), {
-        status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      })
-    }
-
-    const body = await req.text()
-    const params = new URLSearchParams(body)
-
-    const messageSid = params.get('MessageSid')
-    const providerStatus = params.get('MessageStatus')
-    const errorMessage = params.get('ErrorMessage')
-
-    if (!messageSid || !providerStatus) {
-      return new Response(JSON.stringify({ skipped: true, reason: 'Missing MessageSid or MessageStatus' }), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      })
-    }
-
-    const status = mapStatus(providerStatus)
-    if (!status) {
-      return new Response(JSON.stringify({ skipped: true, reason: `Unmapped status: ${providerStatus}` }), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      })
-    }
-
+    const payload = rawBody ? JSON.parse(rawBody) : {}
     const supabase = createServiceClient()
+    let processedCount = 0
 
-    const { error: updateError } = await supabase
-      .from('notification_logs')
-      .update({
-        status,
-        error_message: status === 'failed' ? errorMessage || 'Unknown delivery failure' : null,
-      })
-      .eq('message_sid', messageSid)
-      .eq('channel', 'whatsapp')
+    for (const entry of payload?.entry || []) {
+      for (const change of entry?.changes || []) {
+        const statuses = change?.value?.statuses
+        if (!Array.isArray(statuses)) {
+          continue
+        }
 
-    if (updateError) {
-      throw new Error(`Failed to update log status: ${updateError.message}`)
+        for (const providerStatusRecord of statuses) {
+          const messageSid = providerStatusRecord?.id || null
+          const providerStatus = providerStatusRecord?.status || null
+
+          if (!messageSid || !providerStatus) {
+            continue
+          }
+
+          const status = mapStatus(providerStatus)
+          if (!status) {
+            log.warn('Unmapped Meta WhatsApp status received', { messageSid, providerStatus })
+            continue
+          }
+
+          const { error: updateError } = await supabase
+            .from('notification_logs')
+            .update({
+              status,
+              error_message: status === 'failed'
+                ? getMetaStatusErrorMessage(providerStatusRecord?.errors)
+                : null,
+            })
+            .eq('message_sid', messageSid)
+            .eq('channel', 'whatsapp')
+
+          if (updateError) {
+            throw new Error(`Failed to update log status: ${updateError.message}`)
+          }
+
+          processedCount += 1
+          log.info('WhatsApp delivery status updated', { messageSid, providerStatus, status })
+        }
+      }
     }
 
-    log.info('WhatsApp delivery status updated', { messageSid, providerStatus, status })
-
-    return new Response(JSON.stringify({ success: true }), {
+    return new Response(JSON.stringify({ success: true, processedCount }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     })
-  } catch (error) {
+  } catch (error: any) {
     log.error('Failed to process webhook', { error: error.message, stack: error.stack })
 
     return new Response(JSON.stringify({ error: error.message }), {


### PR DESCRIPTION

- Replace Twilio with Meta WhatsApp Cloud API for all transactional messages.
- Implement Meta-specific status webhook with GET verification and POST signature security.
- Update phone normalization to require/handle international formats (defaulting to UK +44 where appropriate).
- Scope transactional emails to 'order_paid' events only.
- Update notification logs to reflect 'meta' provider and store Meta message IDs.
- Clean up redundant 'whatsapp-notify' edge function.