### PR TITLE
feat(harden order create)

### DIFF
--- a/app/src/lib/order-create-items.test.js
+++ b/app/src/lib/order-create-items.test.js
@@ -1,0 +1,48 @@
+import { parseAndAggregateOrderItems } from '../../../supabase/functions/order-create/order-items.ts';
+
+const PRODUCT_A = '11111111-1111-4111-8111-111111111111';
+const PRODUCT_B = '22222222-2222-4222-8222-222222222222';
+
+describe('order-create item parsing', () => {
+  it('keeps valid integer quantities', () => {
+    expect(parseAndAggregateOrderItems([{ product_id: PRODUCT_A, quantity: 2 }])).toEqual([
+      { product_id: PRODUCT_A, quantity: 2 },
+    ]);
+  });
+
+  it('aggregates duplicate product IDs before validation output is used', () => {
+    expect(
+      parseAndAggregateOrderItems([
+        { product_id: PRODUCT_A, quantity: 2 },
+        { product_id: PRODUCT_B, quantity: 1 },
+        { product_id: PRODUCT_A, quantity: 3 },
+      ])
+    ).toEqual([
+      { product_id: PRODUCT_A, quantity: 5 },
+      { product_id: PRODUCT_B, quantity: 1 },
+    ]);
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['decimal', 1.5],
+    ['missing', undefined],
+    ['non-numeric', '2'],
+    ['NaN', Number.NaN],
+  ])('rejects %s quantities', (_name, quantity) => {
+    expect(() => parseAndAggregateOrderItems([{ product_id: PRODUCT_A, quantity }])).toThrow(
+      'Each item quantity must be a positive integer'
+    );
+  });
+
+  it('rejects malformed product IDs', () => {
+    expect(() => parseAndAggregateOrderItems([{ product_id: 'not-a-uuid', quantity: 1 }])).toThrow(
+      'Each item requires a valid product_id'
+    );
+  });
+
+  it('rejects empty item lists', () => {
+    expect(() => parseAndAggregateOrderItems([])).toThrow('At least one item is required');
+  });
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,7 +112,7 @@ Sequence:
 1. Buyer signs in.
 2. Buyer builds a cart in the browser. Cart state is stored locally via Zustand in `localStorage`.
 3. [`Checkout.jsx`](C:/Users/deang/OneDrive/Documents/GitHub/skiip/app/src/pages/attendee/Checkout.jsx) submits only product IDs, quantities, contact details, optional WhatsApp opt-in, notes, and tip.
-4. [`order-create`](C:/Users/deang/OneDrive/Documents/GitHub/skiip/supabase/functions/order-create/index.ts) validates the user, loads products, checks inventory, computes subtotal/tip/total on the server, creates the `orders` row, inserts `order_items`, and writes an `order_created` audit event.
+4. [`order-create`](C:/Users/deang/OneDrive/Documents/GitHub/skiip/supabase/functions/order-create/index.ts) validates the user, rejects malformed quantities, aggregates duplicate product IDs, loads products, checks inventory, computes subtotal/tip/total on the server, persists `orders` and `order_items` atomically through `create_order_with_items_v1()`, and writes an `order_created` audit event.
 5. [`stripe-checkout`](C:/Users/deang/OneDrive/Documents/GitHub/skiip/supabase/functions/stripe-checkout/index.ts) reloads the order, confirms ownership and payable state, verifies the store has completed Stripe onboarding, and creates a Stripe Checkout session.
 6. Checkout is currently GBP-only, and vendor onboarding creates Stripe Express accounts with `country = GB`.
 7. The platform fee is currently computed as `10%` of the order subtotal and passed as `application_fee_amount`.
@@ -195,6 +195,7 @@ Important SQL functions:
 - `finalize_paid_order_inventory()`
 - `restock_order_inventory()`
 - `decrement_inventory()`
+- `create_order_with_items_v1()`
 - `claim_notification_logs()`
 - `get_admin_dashboard_metrics_v1()`
 

--- a/supabase/functions/order-create/index.ts
+++ b/supabase/functions/order-create/index.ts
@@ -4,16 +4,16 @@ import { buildCorsHeaders, isAllowedOrigin, jsonResponse } from "../_shared/http
 import { requireUser } from "../_shared/auth.ts"
 import { createServiceClient } from "../_shared/service.ts"
 import { logger } from "../_shared/logger.ts"
+import {
+  type AggregatedOrderItem,
+  OrderItemValidationError,
+  parseAndAggregateOrderItems,
+} from "./order-items.ts"
 
 const log = logger('order-create')
 
-interface CreateOrderItem {
-  product_id: string
-  quantity: number
-}
-
 interface CreateOrderRequest {
-  items: CreateOrderItem[]
+  items?: unknown
   customer_email?: string
   customer_phone?: string
   notes?: string
@@ -47,13 +47,18 @@ serve(async (req: Request) => {
     const supabase = createServiceClient()
 
     const body = (await req.json()) as CreateOrderRequest
-    const items = Array.isArray(body.items) ? body.items : []
     const tipAmount = roundMoney(Math.max(Number(body.tip_amount || 0), 0))
     const customerEmail = (body.customer_email || '').trim()
     const customerPhone = (body.customer_phone || '').trim()
 
-    if (items.length === 0) {
-      return jsonResponse({ error: 'At least one item is required' }, 400, origin)
+    let normalizedItems: AggregatedOrderItem[]
+    try {
+      normalizedItems = parseAndAggregateOrderItems(body.items)
+    } catch (err: unknown) {
+      if (err instanceof OrderItemValidationError) {
+        return jsonResponse({ error: err.message }, 400, origin)
+      }
+      throw err
     }
 
     if (!customerEmail) {
@@ -68,16 +73,7 @@ serve(async (req: Request) => {
       )
     }
 
-    const normalizedItems = items.map((item) => ({
-      product_id: item.product_id,
-      quantity: Math.max(1, Number(item.quantity) || 0),
-    }))
-
-    if (normalizedItems.some((item) => !item.product_id || item.quantity <= 0)) {
-      return jsonResponse({ error: 'Each item requires a product_id and quantity' }, 400, origin)
-    }
-
-    const productIds = [...new Set(normalizedItems.map((item) => item.product_id))]
+    const productIds = normalizedItems.map((item) => item.product_id)
     const { data: products, error: productsError } = await supabase
       .from('products')
       .select('id, store_id, name, price, images, status, deleted_at, inventory_quantity')
@@ -124,43 +120,29 @@ serve(async (req: Request) => {
     const orderNumber = `ORD-${new Date().toISOString().slice(0, 10).replace(/-/g, '')}-${crypto.randomUUID().slice(0, 8).toUpperCase()}`
 
     const { data: order, error: orderError } = await supabase
-      .from('orders')
-      .insert({
-        order_number: orderNumber,
-        user_id: user.id,
-        store_id: storeIds[0],
-        status: 'pending',
-        subtotal,
-        total,
-        tip_amount: tipAmount,
-        customer_email: customerEmail,
-        customer_phone: customerPhone || null,
-        notes: body.notes?.trim() || null,
-        whatsapp_opt_in: body.whatsapp_opt_in === true,
-        payment_status: 'pending',
-      })
-      .select('id, order_number, subtotal, total, tip_amount, store_id, status')
-      .single()
-
-    if (orderError || !order) {
-      throw orderError || new Error('Failed to create order')
-    }
-
-    const { error: itemsError } = await supabase
-      .from('order_items')
-      .insert(
-        orderItems.map((item) => ({
-          order_id: order.id,
+      .rpc('create_order_with_items_v1', {
+        p_order_number: orderNumber,
+        p_user_id: user.id,
+        p_store_id: storeIds[0],
+        p_subtotal: subtotal,
+        p_total: total,
+        p_tip_amount: tipAmount,
+        p_customer_email: customerEmail,
+        p_customer_phone: customerPhone || null,
+        p_notes: body.notes?.trim() || null,
+        p_whatsapp_opt_in: body.whatsapp_opt_in === true,
+        p_items: orderItems.map((item) => ({
           product_id: item.product_id,
           quantity: item.quantity,
           price: item.price,
           total: item.total,
           product_snapshot: item.product_snapshot,
         })),
-      )
+      })
+      .single()
 
-    if (itemsError) {
-      throw itemsError
+    if (orderError || !order) {
+      throw orderError || new Error('Failed to create order')
     }
 
     await supabase.from('audit_logs').insert({

--- a/supabase/functions/order-create/order-items.ts
+++ b/supabase/functions/order-create/order-items.ts
@@ -1,0 +1,53 @@
+export interface AggregatedOrderItem {
+  product_id: string
+  quantity: number
+}
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export class OrderItemValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'OrderItemValidationError'
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function parseAndAggregateOrderItems(items: unknown): AggregatedOrderItem[] {
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new OrderItemValidationError('At least one item is required')
+  }
+
+  const quantitiesByProduct = new Map<string, number>()
+
+  for (const item of items) {
+    if (!isObject(item)) {
+      throw new OrderItemValidationError('Each item requires a product_id and quantity')
+    }
+
+    const productId = typeof item.product_id === 'string' ? item.product_id.trim() : ''
+    if (!UUID_PATTERN.test(productId)) {
+      throw new OrderItemValidationError('Each item requires a valid product_id')
+    }
+
+    const quantity = item.quantity
+    if (typeof quantity !== 'number' || !Number.isSafeInteger(quantity) || quantity <= 0) {
+      throw new OrderItemValidationError('Each item quantity must be a positive integer')
+    }
+
+    const nextQuantity = (quantitiesByProduct.get(productId) ?? 0) + quantity
+    if (!Number.isSafeInteger(nextQuantity)) {
+      throw new OrderItemValidationError('Item quantity is too large')
+    }
+
+    quantitiesByProduct.set(productId, nextQuantity)
+  }
+
+  return [...quantitiesByProduct.entries()].map(([product_id, quantity]) => ({
+    product_id,
+    quantity,
+  }))
+}

--- a/supabase/functions/stripe-checkout/index.ts
+++ b/supabase/functions/stripe-checkout/index.ts
@@ -114,6 +114,16 @@ serve(async (req: Request) => {
       return jsonResponse({ error: 'Order total mismatch' }, 409, origin)
     }
 
+    const hasInvalidItemQuantity = orderItems.some((item) => {
+      const quantity = Number(item.quantity)
+      return !Number.isSafeInteger(quantity) || quantity <= 0
+    })
+
+    if (hasInvalidItemQuantity) {
+      log.warn('Order has invalid item quantities', { orderId })
+      return jsonResponse({ error: 'Order item quantity is invalid' }, 409, origin)
+    }
+
     const lineItems = orderItems.map((item) => ({
       price_data: {
         currency: 'gbp',
@@ -122,7 +132,7 @@ serve(async (req: Request) => {
         },
         unit_amount: Math.max(1, Math.round(Number(item.price) * 100)),
       },
-      quantity: Math.max(1, Number(item.quantity) || 1),
+      quantity: Number(item.quantity),
     }))
 
     if (tipAmount > 0) {

--- a/supabase/migrations/20260424000000_atomic_order_creation.sql
+++ b/supabase/migrations/20260424000000_atomic_order_creation.sql
@@ -1,0 +1,192 @@
+-- ============================================================
+-- Migration: Atomic server-authoritative order creation
+-- - enforces positive order item quantities for new rows
+-- - creates a service-role-only RPC that persists orders and
+--   order_items in one database transaction
+-- ============================================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'order_items_quantity_positive'
+          AND conrelid = 'public.order_items'::regclass
+    ) THEN
+        ALTER TABLE public.order_items
+        ADD CONSTRAINT order_items_quantity_positive
+        CHECK (quantity > 0) NOT VALID;
+    END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_order_with_items_v1(
+    p_order_number TEXT,
+    p_user_id UUID,
+    p_store_id UUID,
+    p_subtotal NUMERIC,
+    p_total NUMERIC,
+    p_tip_amount NUMERIC,
+    p_customer_email TEXT,
+    p_customer_phone TEXT,
+    p_notes TEXT,
+    p_whatsapp_opt_in BOOLEAN,
+    p_items JSONB
+)
+RETURNS TABLE (
+    id UUID,
+    order_number TEXT,
+    subtotal NUMERIC,
+    total NUMERIC,
+    tip_amount NUMERIC,
+    store_id UUID,
+    status TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_order_id UUID;
+    v_expected_item_count INTEGER;
+    v_inserted_item_count INTEGER;
+BEGIN
+    IF auth.role() IS DISTINCT FROM 'service_role' THEN
+        RAISE EXCEPTION 'FORBIDDEN';
+    END IF;
+
+    IF p_order_number IS NULL OR btrim(p_order_number) = '' THEN
+        RAISE EXCEPTION 'ORDER_NUMBER_REQUIRED';
+    END IF;
+
+    IF p_user_id IS NULL OR p_store_id IS NULL THEN
+        RAISE EXCEPTION 'ORDER_OWNER_AND_STORE_REQUIRED';
+    END IF;
+
+    IF p_customer_email IS NULL OR btrim(p_customer_email) = '' THEN
+        RAISE EXCEPTION 'CUSTOMER_EMAIL_REQUIRED';
+    END IF;
+
+    IF COALESCE(p_subtotal, -1) < 0
+        OR COALESCE(p_total, -1) < 0
+        OR COALESCE(p_tip_amount, -1) < 0 THEN
+        RAISE EXCEPTION 'ORDER_TOTALS_MUST_BE_NON_NEGATIVE';
+    END IF;
+
+    IF jsonb_typeof(p_items) IS DISTINCT FROM 'array' THEN
+        RAISE EXCEPTION 'ORDER_ITEMS_REQUIRED';
+    END IF;
+
+    v_expected_item_count := jsonb_array_length(p_items);
+    IF v_expected_item_count <= 0 THEN
+        RAISE EXCEPTION 'ORDER_ITEMS_REQUIRED';
+    END IF;
+
+    INSERT INTO public.orders AS created_order (
+        order_number,
+        user_id,
+        store_id,
+        status,
+        subtotal,
+        total,
+        tip_amount,
+        customer_email,
+        customer_phone,
+        notes,
+        whatsapp_opt_in,
+        payment_status
+    )
+    VALUES (
+        p_order_number,
+        p_user_id,
+        p_store_id,
+        'pending',
+        p_subtotal,
+        p_total,
+        COALESCE(p_tip_amount, 0),
+        p_customer_email,
+        NULLIF(btrim(COALESCE(p_customer_phone, '')), ''),
+        NULLIF(btrim(COALESCE(p_notes, '')), ''),
+        COALESCE(p_whatsapp_opt_in, false),
+        'pending'
+    )
+    RETURNING created_order.id INTO v_order_id;
+
+    INSERT INTO public.order_items (
+        order_id,
+        product_id,
+        quantity,
+        price,
+        total,
+        product_snapshot
+    )
+    SELECT
+        v_order_id,
+        (item.value->>'product_id')::UUID,
+        (item.value->>'quantity')::INTEGER,
+        (item.value->>'price')::NUMERIC,
+        (item.value->>'total')::NUMERIC,
+        COALESCE(item.value->'product_snapshot', '{}'::jsonb)
+    FROM jsonb_array_elements(p_items) AS item(value);
+
+    GET DIAGNOSTICS v_inserted_item_count = ROW_COUNT;
+
+    IF v_inserted_item_count <> v_expected_item_count THEN
+        RAISE EXCEPTION 'ORDER_ITEM_INSERT_COUNT_MISMATCH';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        o.id,
+        o.order_number,
+        o.subtotal,
+        o.total,
+        o.tip_amount,
+        o.store_id,
+        o.status
+    FROM public.orders o
+    WHERE o.id = v_order_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_order_with_items_v1(
+    TEXT,
+    UUID,
+    UUID,
+    NUMERIC,
+    NUMERIC,
+    NUMERIC,
+    TEXT,
+    TEXT,
+    TEXT,
+    BOOLEAN,
+    JSONB
+) FROM PUBLIC;
+
+REVOKE ALL ON FUNCTION public.create_order_with_items_v1(
+    TEXT,
+    UUID,
+    UUID,
+    NUMERIC,
+    NUMERIC,
+    NUMERIC,
+    TEXT,
+    TEXT,
+    TEXT,
+    BOOLEAN,
+    JSONB
+) FROM anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.create_order_with_items_v1(
+    TEXT,
+    UUID,
+    UUID,
+    NUMERIC,
+    NUMERIC,
+    NUMERIC,
+    TEXT,
+    TEXT,
+    TEXT,
+    BOOLEAN,
+    JSONB
+) TO service_role;

--- a/supabase/tests/create_order_with_items_v1_rollback.sql
+++ b/supabase/tests/create_order_with_items_v1_rollback.sql
@@ -1,0 +1,123 @@
+-- Verifies that create_order_with_items_v1 rolls back the orders row
+-- when one order_items insert fails. Run against a reset local Supabase DB.
+
+BEGIN;
+
+DO $$
+DECLARE
+    v_buyer_id UUID := gen_random_uuid();
+    v_seller_id UUID := gen_random_uuid();
+    v_store_id UUID := gen_random_uuid();
+    v_product_id UUID := gen_random_uuid();
+    v_missing_product_id UUID := gen_random_uuid();
+    v_order_number TEXT := 'TEST-ROLLBACK-' || replace(gen_random_uuid()::text, '-', '');
+    v_persisted_orders INTEGER;
+BEGIN
+    PERFORM set_config('request.jwt.claim.role', 'service_role', true);
+
+    INSERT INTO auth.users (
+        id,
+        instance_id,
+        aud,
+        role,
+        email,
+        encrypted_password,
+        email_confirmed_at,
+        created_at,
+        updated_at
+    )
+    VALUES
+        (
+            v_buyer_id,
+            '00000000-0000-0000-0000-000000000000',
+            'authenticated',
+            'authenticated',
+            'rollback-buyer@example.com',
+            'not-used',
+            NOW(),
+            NOW(),
+            NOW()
+        ),
+        (
+            v_seller_id,
+            '00000000-0000-0000-0000-000000000000',
+            'authenticated',
+            'authenticated',
+            'rollback-seller@example.com',
+            'not-used',
+            NOW(),
+            NOW(),
+            NOW()
+        );
+
+    INSERT INTO public.stores (id, user_id, name, slug, status)
+    VALUES (v_store_id, v_seller_id, 'Rollback Test Store', 'rollback-test-store', 'active');
+
+    INSERT INTO public.products (
+        id,
+        store_id,
+        name,
+        slug,
+        price,
+        inventory_quantity,
+        status
+    )
+    VALUES (
+        v_product_id,
+        v_store_id,
+        'Rollback Test Product',
+        'rollback-test-product',
+        10.00,
+        10,
+        'active'
+    );
+
+    BEGIN
+        PERFORM *
+        FROM public.create_order_with_items_v1(
+            v_order_number,
+            v_buyer_id,
+            v_store_id,
+            20.00,
+            20.00,
+            0.00,
+            'rollback-buyer@example.com',
+            NULL,
+            NULL,
+            false,
+            jsonb_build_array(
+                jsonb_build_object(
+                    'product_id', v_product_id,
+                    'quantity', 1,
+                    'price', 10.00,
+                    'total', 10.00,
+                    'product_snapshot', jsonb_build_object('name', 'Rollback Test Product')
+                ),
+                jsonb_build_object(
+                    'product_id', v_missing_product_id,
+                    'quantity', 1,
+                    'price', 10.00,
+                    'total', 10.00,
+                    'product_snapshot', jsonb_build_object('name', 'Missing Product')
+                )
+            )
+        );
+
+        RAISE EXCEPTION 'Expected create_order_with_items_v1 to fail';
+    EXCEPTION
+        WHEN foreign_key_violation THEN
+            NULL;
+    END;
+
+    SELECT COUNT(*)
+    INTO v_persisted_orders
+    FROM public.orders
+    WHERE order_number = v_order_number;
+
+    IF v_persisted_orders <> 0 THEN
+        RAISE EXCEPTION 'Rollback failed: % order rows persisted', v_persisted_orders;
+    END IF;
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
Added strict order item parsing/aggregation in order-items.ts (line 19). Updated order-create (line 56) to aggregate duplicate products and persist through create_order_with_items_v1. Added atomic Supabase RPC migration in 20260424000000_atomic_order_creation.sql (line 23). Added Stripe checkout quantity guard in stripe-checkout (line 117). Added helper unit tests and a rollback verification SQL script under supabase/tests.