### PR TITLE
fix(payments)!: add pending payment recovery controls

### DIFF
--- a/app/src/lib/orders.js
+++ b/app/src/lib/orders.js
@@ -17,7 +17,7 @@ export function calculateOrderSummary(items, tipAmount = 0) {
 
 export function getAllowedOrderTransitions(status) {
   const transitions = {
-    pending: [],
+    pending: ['cancelled'],
     paid: ['preparing', 'cancelled'],
     preparing: ['ready', 'cancelled'],
     ready: ['collected', 'cancelled'],
@@ -27,6 +27,21 @@ export function getAllowedOrderTransitions(status) {
   };
 
   return transitions[status] || [];
+}
+
+export function isUnpaidPendingOrder(order) {
+  return (
+    order?.status === 'pending'
+    && ['pending', 'failed'].includes(order?.payment_status || 'pending')
+  );
+}
+
+export function canContinuePendingPayment(order) {
+  return isUnpaidPendingOrder(order);
+}
+
+export function canCancelUnpaidOrder(order) {
+  return isUnpaidPendingOrder(order);
 }
 
 export const VENDOR_ORDER_LANE_DEFINITIONS = [
@@ -189,6 +204,32 @@ export function getVendorOrderActionHint(order) {
   }
 
   return 'Review order state before taking action.';
+}
+
+export function getBuyerOrderStatusLabel(order) {
+  if (isUnpaidPendingOrder(order)) {
+    return order?.payment_status === 'failed' ? 'Payment failed' : 'Payment pending';
+  }
+
+  return getOrderStatusLabel(order);
+}
+
+export function getBuyerOrderStatusDescription(order) {
+  if (isUnpaidPendingOrder(order)) {
+    return order?.payment_status === 'failed'
+      ? 'Payment did not complete. You can try again or cancel this order.'
+      : 'Your order is waiting for payment. The vendor will not start preparing it yet.';
+  }
+
+  if (order?.status === 'paid') {
+    return 'Payment is complete. The vendor can start preparing your order.';
+  }
+
+  if (order?.status === 'cancelled') {
+    return 'This order has been cancelled.';
+  }
+
+  return null;
 }
 
 export function isRefundableOrder(order) {

--- a/app/src/lib/orders.test.js
+++ b/app/src/lib/orders.test.js
@@ -11,6 +11,10 @@ import {
   getVendorPrimaryTransition,
   getVendorTransitionSuccessMessage,
   groupVendorOrdersByLane,
+  canCancelUnpaidOrder,
+  canContinuePendingPayment,
+  getBuyerOrderStatusDescription,
+  getBuyerOrderStatusLabel,
   isPaymentReconciliationCandidate,
   isRefundableOrder,
   roundCurrency,
@@ -40,7 +44,24 @@ describe('order utilities', () => {
 
   it('returns production-safe order transitions', () => {
     expect(getAllowedOrderTransitions('paid')).toEqual(['preparing', 'cancelled']);
-    expect(getAllowedOrderTransitions('pending')).toEqual([]);
+    expect(getAllowedOrderTransitions('pending')).toEqual(['cancelled']);
+  });
+
+  it('detects unpaid pending orders that buyers can recover or cancel', () => {
+    expect(canContinuePendingPayment({ status: 'pending', payment_status: 'pending' })).toBe(true);
+    expect(canCancelUnpaidOrder({ status: 'pending', payment_status: 'failed' })).toBe(true);
+    expect(canCancelUnpaidOrder({ status: 'pending', payment_status: 'succeeded' })).toBe(false);
+    expect(canContinuePendingPayment({ status: 'paid', payment_status: 'succeeded' })).toBe(false);
+  });
+
+  it('returns buyer-safe pending payment copy', () => {
+    const pendingOrder = { status: 'pending', payment_status: 'pending' };
+    const failedOrder = { status: 'pending', payment_status: 'failed' };
+
+    expect(getBuyerOrderStatusLabel(pendingOrder)).toBe('Payment pending');
+    expect(getBuyerOrderStatusDescription(pendingOrder)).toContain('waiting for payment');
+    expect(getBuyerOrderStatusLabel(failedOrder)).toBe('Payment failed');
+    expect(getBuyerOrderStatusDescription(failedOrder)).toContain('try again');
   });
 
   it('detects refundable orders', () => {

--- a/app/src/pages/attendee/BuyerProfile.jsx
+++ b/app/src/pages/attendee/BuyerProfile.jsx
@@ -2,12 +2,22 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../lib/context/AuthContext';
 import { supabase, isSupabaseConfigured } from '../../lib/supabase';
+import { OrderService } from '../../lib/services/order.service';
+import { StripeService } from '../../lib/services/stripe.service';
+import { useToast } from '../../components/ui/Toast';
+import {
+    canCancelUnpaidOrder,
+    canContinuePendingPayment,
+    getBuyerOrderStatusLabel,
+} from '../../lib/orders';
 
 export default function BuyerProfile() {
     const { user, profile, loading: authLoading } = useAuth();
     const navigate = useNavigate();
     const [orders, setOrders] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [actionBusy, setActionBusy] = useState(null);
+    const { addToast } = useToast();
 
     useEffect(() => {
         if (authLoading) return;
@@ -39,7 +49,64 @@ export default function BuyerProfile() {
         }
 
         fetchHistory();
-    }, [user, navigate]);
+    }, [authLoading, user, navigate]);
+
+    async function handleContinuePayment(event, order) {
+        event.stopPropagation();
+
+        if (!isSupabaseConfigured()) {
+            addToast('Demo mode: payment recovery simulated.', 'info');
+            return;
+        }
+
+        setActionBusy(`${order.id}:payment`);
+        try {
+            const session = await StripeService.createCheckoutSession({
+                orderId: order.id,
+                returnUrl: window.location.origin + '/#/order/track',
+            });
+
+            if (session?.url) {
+                window.location.href = session.url;
+                return;
+            }
+
+            throw new Error('Failed to generate payment link');
+        } catch (error) {
+            console.error('Continue payment failed:', error);
+            addToast(error.buyerMessage || 'Could not restart payment. Please try again.', 'error');
+        } finally {
+            setActionBusy(null);
+        }
+    }
+
+    async function handleCancelOrder(event, order) {
+        event.stopPropagation();
+
+        if (!isSupabaseConfigured()) {
+            setOrders((current) => current.map((item) => (
+                item.id === order.id ? { ...item, status: 'cancelled' } : item
+            )));
+            addToast('Demo mode: order cancelled.', 'info');
+            return;
+        }
+
+        setActionBusy(`${order.id}:cancel`);
+        try {
+            const updatedOrder = await OrderService.updateOrderStatus(order.id, 'cancelled');
+            setOrders((current) => current.map((item) => (
+                item.id === order.id
+                    ? { ...item, ...(updatedOrder || {}), status: updatedOrder?.status || 'cancelled' }
+                    : item
+            )));
+            addToast('Order cancelled.', 'success');
+        } catch (error) {
+            console.error('Cancel order failed:', error);
+            addToast('Could not cancel this order. Refresh and try again.', 'error');
+        } finally {
+            setActionBusy(null);
+        }
+    }
 
     if (authLoading) return <div className="container" style={{ paddingTop: '60px' }}>Loading profile...</div>;
     if (!user) return null;
@@ -70,31 +137,75 @@ export default function BuyerProfile() {
                     </div>
                 ) : (
                     <div className="flex flex-col gap-16">
-                        {orders.map(order => (
-                            <div key={order.id} className="card flex justify-between items-center" onClick={() => navigate(`/order/track/${order.id}`)} style={{ cursor: 'pointer', transition: 'transform 0.2s' }} onMouseEnter={e => e.currentTarget.style.transform = 'translateY(-2px)'} onMouseLeave={e => e.currentTarget.style.transform = 'translateY(0)'}>
-                                <div className="flex gap-16 items-center">
-                                    {order.stores?.logo_url ? (
-                                        <img src={order.stores.logo_url} alt={order.stores.name} style={{ width: '48px', height: '48px', borderRadius: '8px', objectFit: 'cover' }} />
-                                    ) : (
-                                        <div style={{ width: '48px', height: '48px', borderRadius: '8px', background: 'rgba(255,255,255,0.05)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                                            🍽️
+                        {orders.map((order) => {
+                            const canContinuePayment = canContinuePendingPayment(order);
+                            const canCancelOrder = canCancelUnpaidOrder(order);
+                            const paymentBusy = actionBusy === `${order.id}:payment`;
+                            const cancelBusy = actionBusy === `${order.id}:cancel`;
+                            const statusLabel = getBuyerOrderStatusLabel(order);
+
+                            return (
+                                <div
+                                    key={order.id}
+                                    className="card"
+                                    onClick={() => navigate(`/order/track/${order.id}`)}
+                                    style={{ cursor: 'pointer', transition: 'transform 0.2s', display: 'grid', gap: '14px' }}
+                                    onMouseEnter={e => e.currentTarget.style.transform = 'translateY(-2px)'}
+                                    onMouseLeave={e => e.currentTarget.style.transform = 'translateY(0)'}
+                                >
+                                    <div className="flex justify-between items-center">
+                                        <div className="flex gap-16 items-center">
+                                            {order.stores?.logo_url ? (
+                                                <img src={order.stores.logo_url} alt={order.stores.name} style={{ width: '48px', height: '48px', borderRadius: '8px', objectFit: 'cover' }} />
+                                            ) : (
+                                                <div style={{ width: '48px', height: '48px', borderRadius: '8px', background: 'rgba(255,255,255,0.05)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                                                    🍽️
+                                                </div>
+                                            )}
+                                            <div>
+                                                <h4 style={{ marginBottom: '4px' }}>{order.stores?.name || 'Unknown Store'}</h4>
+                                                <p className="text-muted" style={{ fontSize: '13px' }}>
+                                                    {new Date(order.created_at).toLocaleDateString()} • {order.order_number}
+                                                </p>
+                                            </div>
+                                        </div>
+                                        <div style={{ textAlign: 'right' }}>
+                                            <h4 style={{ marginBottom: '4px' }}>£{parseFloat(order.total).toFixed(2)}</h4>
+                                            <span style={{ fontSize: '12px', padding: '2px 8px', borderRadius: '12px', background: order.status === 'collected' ? 'rgba(16, 185, 129, 0.2)' : 'rgba(245, 158, 11, 0.2)', color: order.status === 'collected' ? '#10b981' : '#f59e0b' }}>
+                                                {statusLabel}
+                                            </span>
+                                        </div>
+                                    </div>
+
+                                    {(canContinuePayment || canCancelOrder) && (
+                                        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                                            {canContinuePayment && (
+                                                <button
+                                                    type="button"
+                                                    className="btn btn-primary"
+                                                    disabled={Boolean(actionBusy)}
+                                                    onClick={(event) => handleContinuePayment(event, order)}
+                                                    style={{ minHeight: '38px', padding: '8px 12px', borderRadius: '8px', fontSize: '13px' }}
+                                                >
+                                                    {paymentBusy ? 'Opening payment...' : 'Continue payment'}
+                                                </button>
+                                            )}
+                                            {canCancelOrder && (
+                                                <button
+                                                    type="button"
+                                                    className="btn btn-ghost"
+                                                    disabled={Boolean(actionBusy)}
+                                                    onClick={(event) => handleCancelOrder(event, order)}
+                                                    style={{ minHeight: '38px', padding: '8px 12px', borderRadius: '8px', fontSize: '13px', color: '#f87171' }}
+                                                >
+                                                    {cancelBusy ? 'Cancelling...' : 'Cancel order'}
+                                                </button>
+                                            )}
                                         </div>
                                     )}
-                                    <div>
-                                        <h4 style={{ marginBottom: '4px' }}>{order.stores?.name || 'Unknown Store'}</h4>
-                                        <p className="text-muted" style={{ fontSize: '13px' }}>
-                                            {new Date(order.created_at).toLocaleDateString()} • {order.order_number}
-                                        </p>
-                                    </div>
                                 </div>
-                                <div style={{ textAlign: 'right' }}>
-                                    <h4 style={{ marginBottom: '4px' }}>£{parseFloat(order.total).toFixed(2)}</h4>
-                                    <span style={{ fontSize: '12px', padding: '2px 8px', borderRadius: '12px', background: order.status === 'collected' ? 'rgba(16, 185, 129, 0.2)' : 'rgba(245, 158, 11, 0.2)', color: order.status === 'collected' ? '#10b981' : '#f59e0b' }}>
-                                        {order.status.toUpperCase()}
-                                    </span>
-                                </div>
-                            </div>
-                        ))}
+                            );
+                        })}
                     </div>
                 )}
             </div>

--- a/app/src/pages/attendee/OrderTracker.jsx
+++ b/app/src/pages/attendee/OrderTracker.jsx
@@ -2,10 +2,18 @@ import React, { useEffect, useState } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { supabase, isSupabaseConfigured } from '../../lib/supabase';
 import { OrderService } from '../../lib/services/order.service';
+import { StripeService } from '../../lib/services/stripe.service';
 import { useCart } from '../../lib/hooks/useCart';
 import { useToast } from '../../components/ui/Toast';
 import LoadingSkeleton from '../../components/ui/LoadingSkeleton';
 import { getScheduledCollectionLabel } from '../../lib/scheduledCollection';
+import {
+    canCancelUnpaidOrder,
+    canContinuePendingPayment,
+    getBuyerOrderStatusDescription,
+    getBuyerOrderStatusLabel,
+    getOrderStatusColor,
+} from '../../lib/orders';
 
 const STATUS_CONFIG = {
     pending: { label: 'Order Placed', color: '#9b9ba5', icon: '📝' },
@@ -33,12 +41,14 @@ export default function OrderTracker() {
     const [loading, setLoading] = useState(true);
     const [connectionStatus, setConnectionStatus] = useState('connected'); // connected, reconnecting, error
     const [showSuccessOverlay, setShowSuccessOverlay] = useState(isSuccess);
+    const [actionBusy, setActionBusy] = useState(null);
 
     useEffect(() => {
         if (isCanceled) {
-            addToast('Payment cancelled. Your cart is preserved.', 'info');
-            navigate('/order'); // Go back to vendors
-            return;
+            addToast('Payment was not completed. You can continue payment or cancel the order.', 'info');
+            if (orderId && !pathOrderId) {
+                navigate(`/order/track/${orderId}`, { replace: true });
+            }
         }
 
         if (isSuccess && orderId) {
@@ -87,6 +97,61 @@ export default function OrderTracker() {
             subscription.unsubscribe();
         };
     }, [orderId]);
+
+    async function handleContinuePayment() {
+        if (!order?.id) return;
+
+        if (!isSupabaseConfigured()) {
+            addToast('Demo mode: payment recovery simulated.', 'info');
+            return;
+        }
+
+        setActionBusy('payment');
+        try {
+            const session = await StripeService.createCheckoutSession({
+                orderId: order.id,
+                returnUrl: window.location.origin + '/#/order/track',
+            });
+
+            if (session?.url) {
+                window.location.href = session.url;
+                return;
+            }
+
+            throw new Error('Failed to generate payment link');
+        } catch (error) {
+            console.error('Continue payment failed:', error);
+            addToast(error.buyerMessage || 'Could not restart payment. Please try again.', 'error');
+        } finally {
+            setActionBusy(null);
+        }
+    }
+
+    async function handleCancelOrder() {
+        if (!order?.id) return;
+
+        if (!isSupabaseConfigured()) {
+            setOrder((current) => ({ ...current, status: 'cancelled' }));
+            addToast('Demo mode: order cancelled.', 'info');
+            return;
+        }
+
+        setActionBusy('cancel');
+        try {
+            const updatedOrder = await OrderService.updateOrderStatus(order.id, 'cancelled');
+            setOrder((current) => ({
+                ...current,
+                ...(updatedOrder || {}),
+                status: updatedOrder?.status || 'cancelled',
+            }));
+            addToast('Order cancelled.', 'success');
+        } catch (error) {
+            console.error('Cancel order failed:', error);
+            addToast('Could not cancel this order. Refresh and try again.', 'error');
+        } finally {
+            setActionBusy(null);
+        }
+    }
 
     async function fetchOrder() {
         try {
@@ -143,6 +208,11 @@ export default function OrderTracker() {
     const statusConfig = STATUS_CONFIG[order.status] || STATUS_CONFIG.pending;
     const orderItems = order.order_items || [];
     const scheduledCollectionLabel = getScheduledCollectionLabel(order);
+    const canContinuePayment = canContinuePendingPayment(order);
+    const canCancelOrder = canCancelUnpaidOrder(order);
+    const buyerStatusLabel = getBuyerOrderStatusLabel(order);
+    const buyerStatusDescription = getBuyerOrderStatusDescription(order);
+    const buyerStatusColor = getOrderStatusColor(order);
 
     return (
         <>
@@ -207,13 +277,51 @@ export default function OrderTracker() {
                 </div>
 
                 {/* Status Card */}
-                <div className="card" style={{ textAlign: 'center', padding: '40px', marginBottom: '24px', border: `2px solid ${statusConfig.color}` }}>
+                <div className="card" style={{ textAlign: 'center', padding: '40px', marginBottom: '24px', border: `2px solid ${buyerStatusColor}` }}>
                     <div style={{ fontSize: '60px', marginBottom: '16px' }}>{statusConfig.icon}</div>
-                    <h1 style={{ fontSize: '32px', fontWeight: '800', marginBottom: '8px', color: statusConfig.color }}>
-                        {statusConfig.label}
+                    <h1 style={{ fontSize: '32px', fontWeight: '800', marginBottom: '8px', color: buyerStatusColor }}>
+                        {buyerStatusLabel}
                     </h1>
                     <p className="text-muted">Order #{order.id.slice(0, 8)}</p>
+                    {buyerStatusDescription && (
+                        <p className="text-muted" style={{ maxWidth: '360px', margin: '12px auto 0', lineHeight: 1.5 }}>
+                            {buyerStatusDescription}
+                        </p>
+                    )}
                 </div>
+
+                {(canContinuePayment || canCancelOrder) && (
+                    <div className="card" style={{ marginBottom: '24px', border: '1px solid rgba(245, 158, 11, 0.45)' }}>
+                        <h3 style={{ marginBottom: '8px' }}>Payment needed</h3>
+                        <p className="text-muted" style={{ marginBottom: '16px', lineHeight: 1.5 }}>
+                            This order has not been paid for yet. Continue to secure payment or cancel it if you no longer need it.
+                        </p>
+                        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                            {canContinuePayment && (
+                                <button
+                                    type="button"
+                                    className="btn btn-primary"
+                                    disabled={Boolean(actionBusy)}
+                                    onClick={handleContinuePayment}
+                                    style={{ minHeight: '42px', borderRadius: '8px' }}
+                                >
+                                    {actionBusy === 'payment' ? 'Opening payment...' : 'Continue payment'}
+                                </button>
+                            )}
+                            {canCancelOrder && (
+                                <button
+                                    type="button"
+                                    className="btn btn-ghost"
+                                    disabled={Boolean(actionBusy)}
+                                    onClick={handleCancelOrder}
+                                    style={{ minHeight: '42px', borderRadius: '8px', color: '#f87171' }}
+                                >
+                                    {actionBusy === 'cancel' ? 'Cancelling...' : 'Cancel order'}
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                )}
 
                 {/* Vendor Info */}
                 {vendor && (

--- a/app/src/pages/vendor/Dashboard.jsx
+++ b/app/src/pages/vendor/Dashboard.jsx
@@ -20,6 +20,7 @@ import {
     getVendorPrimaryTransition,
     getVendorTransitionSuccessMessage,
     groupVendorOrdersByLane,
+    canCancelUnpaidOrder,
 } from '../../lib/orders';
 
 const FILTERS = [
@@ -98,7 +99,8 @@ function VendorOrderCard({ order, isBusy, onTransition }) {
     const scheduledCollectionLabel = getScheduledCollectionLabel(order);
     const allowedTransitions = getAllowedOrderTransitions(order.status);
     const primaryTransition = getVendorPrimaryTransition(order.status);
-    const canCancel = allowedTransitions.includes('cancelled');
+    const canCancel = allowedTransitions.includes('cancelled')
+        && (order.status !== 'pending' || canCancelUnpaidOrder(order));
     const contact = getOrderContact(order);
     const itemSummary = getVendorOrderItemSummary(order);
     const actionHint = getVendorOrderActionHint(order);

--- a/supabase/functions/order-transition/index.ts
+++ b/supabase/functions/order-transition/index.ts
@@ -9,7 +9,7 @@ import { sendTransactionalNotificationsBestEffort } from "../_shared/notificatio
 const log = logger('order-transition')
 
 const ALLOWED_TRANSITIONS: Record<string, string[]> = {
-  pending: [],
+  pending: ['cancelled'],
   paid: ['preparing', 'cancelled'],
   preparing: ['ready', 'cancelled'],
   ready: ['collected', 'cancelled'],
@@ -57,7 +57,7 @@ serve(async (req: Request) => {
 
     const { data: order, error: orderError } = await supabase
       .from('orders')
-      .select('id, store_id, status, payment_status, inventory_committed_at, inventory_restocked_at')
+      .select('id, user_id, store_id, status, payment_status, inventory_committed_at, inventory_restocked_at')
       .eq('id', body.orderId)
       .single()
 
@@ -65,7 +65,14 @@ serve(async (req: Request) => {
       return jsonResponse({ error: 'Order not found' }, 404, origin)
     }
 
-    if (user.role !== 'admin') {
+    const isUnpaidPendingCancellation = (
+      order.status === 'pending'
+      && body.status === 'cancelled'
+      && ['pending', 'failed'].includes(order.payment_status || 'pending')
+    )
+    const isBuyerOwnedCancellation = isUnpaidPendingCancellation && order.user_id === user.id
+
+    if (user.role !== 'admin' && !isBuyerOwnedCancellation) {
       const { data: store, error: storeError } = await supabase
         .from('stores')
         .select('id')
@@ -91,6 +98,14 @@ serve(async (req: Request) => {
       )
     }
 
+    if (order.status === 'pending' && body.status === 'cancelled' && !isUnpaidPendingCancellation) {
+      return jsonResponse(
+        { error: 'Only unpaid pending orders can be cancelled through this path' },
+        409,
+        origin,
+      )
+    }
+
     const updates: Record<string, unknown> = { status: body.status }
     if (body.status === 'cancelled') {
       updates.cancelled_at = new Date().toISOString()
@@ -107,11 +122,13 @@ serve(async (req: Request) => {
       .from('orders')
       .update(updates)
       .eq('id', order.id)
+      .eq('status', order.status)
+      .eq('payment_status', order.payment_status)
       .select('id, status')
-      .single()
+      .maybeSingle()
 
     if (updateError || !updatedOrder) {
-      throw updateError || new Error('Failed to update order')
+      throw updateError || new Error('Order state changed before transition could be applied')
     }
 
     await supabase.from('audit_logs').insert({

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -200,6 +200,76 @@ async function handleCheckoutSessionCompleted(supabase: any, event: Stripe.Event
 
   const paymentIntent = await retrievePaymentIntentWithCharge(stripe, paymentIntentId)
   const reconciliation = buildPaymentReconciliation(paymentIntent, Number(order.total || 0))
+
+  if (order.status === 'cancelled') {
+    log.warn('Checkout completed after order was cancelled; refunding payment', {
+      orderId,
+      eventId: event.id,
+      paymentIntentId: reconciliation.paymentIntentId,
+    })
+
+    const refund = await stripe.refunds.create(
+      {
+        payment_intent: reconciliation.paymentIntentId,
+        reason: 'requested_by_customer',
+        metadata: {
+          order_id: orderId,
+          auto_refund_reason: 'completed_after_order_cancelled',
+        },
+      },
+      {
+        idempotencyKey: `cancelled-order-auto-refund-${orderId}-${reconciliation.paymentIntentId}`,
+      },
+    )
+
+    const { error: refundUpdateError } = await supabase
+      .from('orders')
+      .update({
+        status: 'refunded',
+        payment_status: 'refunded',
+        payment_intent_id: reconciliation.paymentIntentId,
+        charge_id: reconciliation.chargeId,
+        refund_id: refund.id,
+        refund_amount: Number(order.total || 0),
+        refund_reason: 'Automatic refund: payment completed after order was cancelled',
+        refunded_at: new Date().toISOString(),
+      })
+      .eq('id', orderId)
+
+    if (refundUpdateError) {
+      throw refundUpdateError
+    }
+
+    await runBestEffort('Cancelled-order refund audit log', () => recordAuditLog(supabase, {
+      event_type: 'order_refunded',
+      entity_type: 'order',
+      entity_id: orderId,
+      actor_role: 'system',
+      payload: {
+        reason: 'completed_after_order_cancelled',
+        refund_id: refund.id,
+        stripe_event_id: event.id,
+      },
+    }))
+
+    await sendTransactionalNotificationsBestEffort({
+      supabase,
+      orderId,
+      eventType: 'order_refunded',
+      sourceEventId: event.id,
+      functionName: 'stripe-webhook',
+      operation: 'completed_after_order_cancelled_auto_refund',
+      metadata: {
+        stripeEventId: event.id,
+        stripeEventType: event.type,
+        refundId: refund.id,
+        paymentIntentId: reconciliation.paymentIntentId,
+      },
+    })
+
+    return
+  }
+
   const paidOrderUpdates = {
     ...buildPaidOrderUpdates(reconciliation),
     paid_at: order.paid_at || reconciliation.paidAt,


### PR DESCRIPTION
## Summary
- fixes #49 by adding buyer continue-payment and unpaid-order cancellation controls
- lets vendors cancel unpaid pending orders from the Needs review lane
- updates order-transition so authorized unpaid pending orders can move to cancelled
- adds a Stripe webhook safeguard that auto-refunds late checkout completions for already-cancelled orders

## Breaking change
- order-transition behavior changes: pending orders may now transition to cancelled only when payment_status is pending or failed, and only for the owning buyer, store vendor, or admin.

## Verification
- npm run test -- orders.test.js
- npm run test
- npm run lint
- npm run build

## Notes
- I could not keep a local Vite dev server running from this shell because Windows background process startup failed with a duplicate PATH environment error. The production build passed.