### PR TITLE
fix(orders): make unpaid cancellation idempotent

### DIFF
--- a/supabase/functions/_shared/order-transitions.ts
+++ b/supabase/functions/_shared/order-transitions.ts
@@ -1,0 +1,59 @@
+export const ALLOWED_ORDER_TRANSITIONS: Record<string, string[]> = {
+  pending: ["cancelled"],
+  paid: ["preparing", "cancelled"],
+  preparing: ["ready", "cancelled"],
+  ready: ["collected", "cancelled"],
+  collected: [],
+  cancelled: [],
+  refunded: [],
+};
+
+export interface OrderTransitionSnapshot {
+  status: string;
+  payment_status?: string | null;
+  user_id?: string | null;
+}
+
+export function getAllowedOrderTransitions(status: string) {
+  return ALLOWED_ORDER_TRANSITIONS[status] || [];
+}
+
+export function isUnpaidPaymentStatus(
+  paymentStatus: string | null | undefined,
+) {
+  return ["pending", "failed"].includes(paymentStatus || "pending");
+}
+
+export function isPendingUnpaidCancellation(
+  order: OrderTransitionSnapshot,
+  nextStatus: string,
+) {
+  return (
+    order.status === "pending" &&
+    nextStatus === "cancelled" &&
+    isUnpaidPaymentStatus(order.payment_status)
+  );
+}
+
+export function isIdempotentUnpaidCancellation(
+  order: OrderTransitionSnapshot,
+  nextStatus: string,
+) {
+  return (
+    order.status === "cancelled" &&
+    nextStatus === "cancelled" &&
+    isUnpaidPaymentStatus(order.payment_status)
+  );
+}
+
+export function isBuyerOwnedUnpaidCancellation(
+  order: OrderTransitionSnapshot,
+  nextStatus: string,
+  userId: string,
+) {
+  return (
+    (isPendingUnpaidCancellation(order, nextStatus) ||
+      isIdempotentUnpaidCancellation(order, nextStatus)) &&
+    order.user_id === userId
+  );
+}

--- a/supabase/functions/order-transition/index.ts
+++ b/supabase/functions/order-transition/index.ts
@@ -5,18 +5,14 @@ import { getAuthErrorStatus, requireUser } from "../_shared/auth.ts"
 import { createServiceClient } from "../_shared/service.ts"
 import { logger } from "../_shared/logger.ts"
 import { sendTransactionalNotificationsBestEffort } from "../_shared/notifications.ts"
+import {
+  getAllowedOrderTransitions,
+  isBuyerOwnedUnpaidCancellation,
+  isIdempotentUnpaidCancellation,
+  isPendingUnpaidCancellation,
+} from "../_shared/order-transitions.ts"
 
 const log = logger('order-transition')
-
-const ALLOWED_TRANSITIONS: Record<string, string[]> = {
-  pending: ['cancelled'],
-  paid: ['preparing', 'cancelled'],
-  preparing: ['ready', 'cancelled'],
-  ready: ['collected', 'cancelled'],
-  collected: [],
-  cancelled: [],
-  refunded: [],
-}
 
 const EVENT_MAP: Record<string, 'order_preparing' | 'order_ready' | 'order_cancelled' | undefined> = {
   preparing: 'order_preparing',
@@ -65,12 +61,9 @@ serve(async (req: Request) => {
       return jsonResponse({ error: 'Order not found' }, 404, origin)
     }
 
-    const isUnpaidPendingCancellation = (
-      order.status === 'pending'
-      && body.status === 'cancelled'
-      && ['pending', 'failed'].includes(order.payment_status || 'pending')
-    )
-    const isBuyerOwnedCancellation = isUnpaidPendingCancellation && order.user_id === user.id
+    const isUnpaidPendingCancellation = isPendingUnpaidCancellation(order, body.status)
+    const isIdempotentCancellation = isIdempotentUnpaidCancellation(order, body.status)
+    const isBuyerOwnedCancellation = isBuyerOwnedUnpaidCancellation(order, body.status, user.id)
 
     if (user.role !== 'admin' && !isBuyerOwnedCancellation) {
       const { data: store, error: storeError } = await supabase
@@ -89,7 +82,15 @@ serve(async (req: Request) => {
       }
     }
 
-    const allowedNextStatuses = ALLOWED_TRANSITIONS[order.status] || []
+    if (isIdempotentCancellation) {
+      return jsonResponse(
+        { order: { id: order.id, status: order.status } },
+        200,
+        origin,
+      )
+    }
+
+    const allowedNextStatuses = getAllowedOrderTransitions(order.status)
     if (!allowedNextStatuses.includes(body.status)) {
       return jsonResponse(
         { error: `Invalid status transition: ${order.status} -> ${body.status}` },

--- a/supabase/functions/tests/order-transitions-test.ts
+++ b/supabase/functions/tests/order-transitions-test.ts
@@ -1,0 +1,82 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import {
+  getAllowedOrderTransitions,
+  isBuyerOwnedUnpaidCancellation,
+  isIdempotentUnpaidCancellation,
+  isPendingUnpaidCancellation,
+} from "../_shared/order-transitions.ts";
+
+Deno.test("pending unpaid orders can move to cancelled", () => {
+  assertEquals(
+    isPendingUnpaidCancellation(
+      { status: "pending", payment_status: "pending" },
+      "cancelled",
+    ),
+    true,
+  );
+  assertEquals(
+    isPendingUnpaidCancellation(
+      { status: "pending", payment_status: "failed" },
+      "cancelled",
+    ),
+    true,
+  );
+});
+
+Deno.test("paid pending orders are excluded from unpaid cancellation", () => {
+  assertEquals(
+    isPendingUnpaidCancellation(
+      { status: "pending", payment_status: "succeeded" },
+      "cancelled",
+    ),
+    false,
+  );
+  assertEquals(
+    isPendingUnpaidCancellation(
+      { status: "paid", payment_status: "succeeded" },
+      "cancelled",
+    ),
+    false,
+  );
+});
+
+Deno.test("already cancelled unpaid orders accept repeated cancellation requests", () => {
+  assertEquals(
+    isIdempotentUnpaidCancellation(
+      { status: "cancelled", payment_status: "pending" },
+      "cancelled",
+    ),
+    true,
+  );
+  assertEquals(
+    isIdempotentUnpaidCancellation(
+      { status: "cancelled", payment_status: "succeeded" },
+      "cancelled",
+    ),
+    false,
+  );
+});
+
+Deno.test("buyers can only repeat unpaid cancellation for their own orders", () => {
+  assertEquals(
+    isBuyerOwnedUnpaidCancellation(
+      { status: "cancelled", payment_status: "pending", user_id: "buyer-1" },
+      "cancelled",
+      "buyer-1",
+    ),
+    true,
+  );
+  assertEquals(
+    isBuyerOwnedUnpaidCancellation(
+      { status: "cancelled", payment_status: "pending", user_id: "buyer-1" },
+      "cancelled",
+      "buyer-2",
+    ),
+    false,
+  );
+});
+
+Deno.test("standard vendor transitions are unchanged", () => {
+  assertEquals(getAllowedOrderTransitions("paid"), ["preparing", "cancelled"]);
+  assertEquals(getAllowedOrderTransitions("cancelled"), []);
+});


### PR DESCRIPTION
## Summary

- Extract order transition predicates into a shared Edge Function helper.
- Treat repeated cancellation requests for already-cancelled unpaid orders as successful idempotent responses.
- Keep paid or succeeded-payment orders excluded from the unpaid cancellation cleanup path.
- Add focused Deno coverage for pending, failed, paid, repeated-cancel, buyer-owned, and unchanged vendor transition cases.

## Validation

- npm run test
- deno test supabase\functions\tests\order-transitions-test.ts
- deno check supabase\functions\order-transition\index.ts
- deno fmt --check supabase\functions\_shared\order-transitions.ts supabase\functions\tests\order-transitions-test.ts

Relates to #49.