### PR TITLE
feat(payments): add live Stripe cutover controls

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,4 +1,3 @@
 VITE_SUPABASE_URL=your_supabase_project_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
-VITE_STRIPE_PUBLIC_KEY=your_stripe_publishable_key
 VITE_SENTRY_DSN=your_sentry_dsn_here

--- a/app/SETUP.md
+++ b/app/SETUP.md
@@ -49,7 +49,6 @@ cp .env.example .env
 ```env
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key-here
-VITE_STRIPE_PUBLIC_KEY=pk_test_...
 VITE_SENTRY_DSN=your-sentry-dsn-here
 ```
 
@@ -60,6 +59,8 @@ Run these commands in your terminal (requires [Supabase CLI](https://supabase.co
 ```bash
 supabase secrets set STRIPE_SECRET_KEY=sk_test_...
 supabase secrets set STRIPE_WEBHOOK_SECRET=whsec_...
+supabase secrets set STRIPE_MODE=test
+supabase secrets set PAYMENTS_ENABLED=true
 supabase secrets set SENTRY_DSN=your-sentry-dsn-here
 supabase secrets set RESEND_API_KEY=re_xxx
 supabase secrets set NOTIFICATION_FROM_EMAIL=orders@yourdomain.com
@@ -74,6 +75,8 @@ supabase secrets set TWILIO_TEMPLATE_ORDER_READY=HX...
 supabase secrets set TWILIO_TEMPLATE_ORDER_CANCELLED=HX...
 supabase secrets set TWILIO_TEMPLATE_ORDER_REFUNDED=HX...
 ```
+
+`PAYMENTS_ENABLED` is the environment master switch. When it is `true`, admins can still pause or resume new buyer checkout from the admin dashboard Payment controls card without changing Stripe secrets.
 
 ### Run the App
 

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -276,6 +276,18 @@ img {
   background: rgba(34, 197, 94, 0.12);
 }
 
+.chip--amber {
+  color: #92400e;
+  border-color: rgba(245, 158, 11, 0.38);
+  background: rgba(245, 158, 11, 0.14);
+}
+
+.chip--red {
+  color: #b91c1c;
+  border-color: rgba(239, 68, 68, 0.38);
+  background: rgba(239, 68, 68, 0.12);
+}
+
 .app-header {
   position: sticky;
   top: 0;

--- a/app/src/lib/services/function-error.js
+++ b/app/src/lib/services/function-error.js
@@ -4,6 +4,7 @@ const VENDOR_NOT_READY_MESSAGE = 'Oops! This vendor is still setting up their ba
 const PRODUCT_UNAVAILABLE_MESSAGE = 'One or more items in your cart are no longer available. Refresh your cart, adjust the items, and try again.';
 const SCHEDULED_COLLECTION_MESSAGE = 'Choose a valid scheduled collection time before checking out.';
 const SESSION_EXPIRED_MESSAGE = 'Your session expired. Please sign in again before checking out.';
+const PAYMENTS_PAUSED_MESSAGE = 'Payments are temporarily unavailable. No payment has been taken. Please try again shortly.';
 
 export class CheckoutFunctionError extends Error {
     constructor(message, { code = null, status = null, payload = null, buyerMessage = GENERIC_CHECKOUT_ERROR_MESSAGE, cause = null } = {}) {
@@ -76,6 +77,10 @@ export function getCheckoutBuyerMessage({ code, status, payload }) {
 
     if (code === 'VENDOR_NOT_READY') {
         return VENDOR_NOT_READY_MESSAGE;
+    }
+
+    if (code === 'PAYMENTS_PAUSED') {
+        return PAYMENTS_PAUSED_MESSAGE;
     }
 
     if (status === 401) {

--- a/app/src/lib/services/function-error.test.js
+++ b/app/src/lib/services/function-error.test.js
@@ -58,6 +58,16 @@ describe('checkout function error mapping', () => {
     expect(error.buyerMessage).toBe('Your session expired. Please sign in again before checking out.');
   });
 
+  it('maps paused payments to a buyer-safe no-payment-taken message', async () => {
+    const error = await createCheckoutFunctionError(functionError({
+      error: 'PAYMENTS_PAUSED',
+      message: 'Payments are temporarily unavailable. No payment has been taken.',
+    }, 503));
+
+    expect(error.code).toBe('PAYMENTS_PAUSED');
+    expect(error.buyerMessage).toBe('Payments are temporarily unavailable. No payment has been taken. Please try again shortly.');
+  });
+
   it('keeps unknown failures generic', async () => {
     const error = await createCheckoutFunctionError(functionError({
       error: 'database statement timeout at internal.stack.trace',

--- a/app/src/lib/services/settings.service.js
+++ b/app/src/lib/services/settings.service.js
@@ -1,7 +1,31 @@
 import { supabase } from '../supabase';
 import { DEFAULT_LAUNCH_EVENT, normalizeLaunchEvent } from '../launch-event';
+import { getFunctionAuthHeaders } from './function-auth';
 
 const LAUNCH_EVENT_KEY = 'launch_event';
+const DEFAULT_PAYMENT_CONTROL_RESPONSE = {
+    controls: {
+        enabled: true,
+        reason: null,
+        updatedAt: null,
+        updatedBy: null,
+    },
+    masterEnabled: false,
+    checkoutEnabled: false,
+};
+
+function normalizePaymentControlResponse(value) {
+    return {
+        controls: {
+            enabled: value?.controls?.enabled !== false,
+            reason: value?.controls?.reason || null,
+            updatedAt: value?.controls?.updatedAt || null,
+            updatedBy: value?.controls?.updatedBy || null,
+        },
+        masterEnabled: value?.masterEnabled === true,
+        checkoutEnabled: value?.checkoutEnabled === true,
+    };
+}
 
 export const SettingsService = {
     async getLaunchEvent() {
@@ -33,5 +57,31 @@ export const SettingsService = {
 
         if (error) throw error;
         return normalizeLaunchEvent(data?.value);
+    },
+
+    async getPaymentControls() {
+        if (!supabase) return DEFAULT_PAYMENT_CONTROL_RESPONSE;
+        const headers = await getFunctionAuthHeaders();
+
+        const { data, error } = await supabase.functions.invoke('payment-control', {
+            headers,
+            body: { action: 'get' },
+        });
+
+        if (error) throw error;
+        return normalizePaymentControlResponse(data);
+    },
+
+    async savePaymentControls({ enabled, reason }) {
+        if (!supabase) return DEFAULT_PAYMENT_CONTROL_RESPONSE;
+        const headers = await getFunctionAuthHeaders();
+
+        const { data, error } = await supabase.functions.invoke('payment-control', {
+            headers,
+            body: { action: 'set', enabled, reason },
+        });
+
+        if (error) throw error;
+        return normalizePaymentControlResponse(data);
     },
 };

--- a/app/src/pages/admin/DashboardV2.jsx
+++ b/app/src/pages/admin/DashboardV2.jsx
@@ -48,6 +48,13 @@ export default function AdminDashboard() {
     const [launchEvent, setLaunchEvent] = useState(DEFAULT_LAUNCH_EVENT);
     const [launchEventDraft, setLaunchEventDraft] = useState(DEFAULT_LAUNCH_EVENT);
     const [savingLaunchEvent, setSavingLaunchEvent] = useState(false);
+    const [paymentControls, setPaymentControls] = useState({
+        controls: { enabled: true, reason: null, updatedAt: null, updatedBy: null },
+        masterEnabled: false,
+        checkoutEnabled: false,
+    });
+    const [paymentPauseReason, setPaymentPauseReason] = useState('');
+    const [savingPaymentControls, setSavingPaymentControls] = useState(false);
     const [stats, setStats] = useState({
         totalOrders: 0,
         activeOrders: 0,
@@ -88,10 +95,11 @@ export default function AdminDashboard() {
     }
 
     async function refreshDashboard() {
-        const [metrics, orders, eventSettings] = await Promise.all([
+        const [metrics, orders, eventSettings, paymentSettings] = await Promise.all([
             AdminService.getDashboardMetrics(),
             AdminService.getRecentOrders(20),
             SettingsService.getLaunchEvent(),
+            SettingsService.getPaymentControls(),
         ]);
 
         setStats({
@@ -108,6 +116,8 @@ export default function AdminDashboard() {
         setRecentOrders(orders || []);
         setLaunchEvent(eventSettings);
         setLaunchEventDraft(eventSettings);
+        setPaymentControls(paymentSettings);
+        setPaymentPauseReason(paymentSettings?.controls?.reason || '');
     }
 
     function updateLaunchEventField(field, value) {
@@ -127,6 +137,24 @@ export default function AdminDashboard() {
             addToast(error.message || 'Could not save launch event copy.', 'error');
         } finally {
             setSavingLaunchEvent(false);
+        }
+    }
+
+    async function handleSetPaymentsEnabled(enabled) {
+        setSavingPaymentControls(true);
+        try {
+            const saved = await SettingsService.savePaymentControls({
+                enabled,
+                reason: enabled ? null : paymentPauseReason || 'Admin paused checkout',
+            });
+            setPaymentControls(saved);
+            setPaymentPauseReason(saved.controls.reason || '');
+            addToast(enabled ? 'Buyer checkout resumed.' : 'Buyer checkout paused.', 'success');
+        } catch (error) {
+            console.error('Payment controls update failed:', error);
+            addToast(error.message || 'Could not update payment controls.', 'error');
+        } finally {
+            setSavingPaymentControls(false);
         }
     }
 
@@ -205,6 +233,64 @@ export default function AdminDashboard() {
                 </section>
 
                 <section className="two-column">
+                    <section className="card" style={{ display: 'grid', gap: '14px' }}>
+                        <div>
+                            <p className="page-kicker">Payment controls</p>
+                            <h2 style={{ color: 'var(--ink)', fontSize: '24px' }}>Checkout switch</h2>
+                            <p className="text-muted" style={{ marginTop: '6px' }}>
+                                Pause buyer checkout for incidents, curfew, or operator stop-sale. Webhooks, refunds, reconciliation, and Connect recovery stay available.
+                            </p>
+                        </div>
+                        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                            <span className={paymentControls.checkoutEnabled ? 'chip chip--green' : 'chip chip--red'}>
+                                Checkout {paymentControls.checkoutEnabled ? 'enabled' : 'paused'}
+                            </span>
+                            <span className={paymentControls.masterEnabled ? 'chip chip--cyan' : 'chip chip--amber'}>
+                                Env master {paymentControls.masterEnabled ? 'on' : 'off'}
+                            </span>
+                            <span className={paymentControls.controls.enabled ? 'chip chip--cyan' : 'chip chip--amber'}>
+                                Admin switch {paymentControls.controls.enabled ? 'on' : 'off'}
+                            </span>
+                        </div>
+                        {!paymentControls.masterEnabled && (
+                            <p className="text-muted" style={{ fontSize: '13px' }}>
+                                <code>PAYMENTS_ENABLED</code> is off in Supabase secrets. Resuming here will not enable checkout until the environment master switch is set to true.
+                            </p>
+                        )}
+                        <div>
+                            <label htmlFor="payment-pause-reason">Pause reason</label>
+                            <input
+                                id="payment-pause-reason"
+                                value={paymentPauseReason}
+                                onChange={(event) => setPaymentPauseReason(event.target.value)}
+                                placeholder="Curfew, incident, vendor issue, or operator stop-sale"
+                            />
+                        </div>
+                        {paymentControls.controls.updatedAt && (
+                            <p className="text-muted" style={{ fontSize: '12px' }}>
+                                Last changed {new Date(paymentControls.controls.updatedAt).toLocaleString()}
+                            </p>
+                        )}
+                        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                            <button
+                                type="button"
+                                className="btn btn-primary"
+                                onClick={() => handleSetPaymentsEnabled(true)}
+                                disabled={savingPaymentControls || paymentControls.controls.enabled}
+                            >
+                                {savingPaymentControls ? 'Updating...' : 'Resume Checkout'}
+                            </button>
+                            <button
+                                type="button"
+                                className="btn btn-danger"
+                                onClick={() => handleSetPaymentsEnabled(false)}
+                                disabled={savingPaymentControls || !paymentControls.controls.enabled}
+                            >
+                                {savingPaymentControls ? 'Updating...' : 'Pause Checkout'}
+                            </button>
+                        </div>
+                    </section>
+
                     <form className="card" onSubmit={handleSaveLaunchEvent} style={{ display: 'grid', gap: '14px' }}>
                         <div>
                             <p className="page-kicker">Launch event</p>

--- a/docs/current-state/known-weak-spots.md
+++ b/docs/current-state/known-weak-spots.md
@@ -12,7 +12,7 @@ These are the main remaining risks in the current baseline.
 
 - `VITE_VENDOR_INVITE_CODE` is no longer part of the launch app route, but stale references may remain in legacy docs or unmounted code
 - `ALLOWED_ORIGINS` has a hardcoded fallback list in code if the env var is missing
-- `VITE_STRIPE_PUBLIC_KEY` is still documented in places even though the current redirect-based checkout flow does not read it
+- `VITE_STRIPE_PUBLIC_KEY` has been removed from active env examples; continue avoiding frontend Stripe public-key setup unless Stripe.js is deliberately reintroduced
 
 ### 3. Local reset and schema guidance still have drift
 

--- a/docs/launch/ENVIRONMENT_MATRIX.md
+++ b/docs/launch/ENVIRONMENT_MATRIX.md
@@ -9,7 +9,7 @@ This is the May 2026 launch source of truth for environment parity. Do not commi
 | `VITE_SUPABASE_URL` | Required | Required | Must point to the matching Supabase project for the anon key. |
 | `VITE_SUPABASE_ANON_KEY` | Required | Required | Public but environment-specific. |
 | `VITE_SENTRY_DSN` | Recommended | Recommended | Browser error reporting. |
-| `VITE_STRIPE_PUBLIC_KEY` | Not required | Not required | Current checkout is redirect-based through edge functions. |
+| `VITE_STRIPE_PUBLIC_KEY` | Removed | Removed | Current checkout is redirect-based through edge functions. Do not set this in Vercel production. |
 | `VITE_VENDOR_INVITE_CODE` | Not required | Not required | Vendor onboarding is admin-created for launch. |
 
 ## Vercel Project Features
@@ -31,6 +31,8 @@ This is the May 2026 launch source of truth for environment parity. Do not commi
 | `ALLOWED_ORIGINS` | Required | Required | Comma-separated exact frontend origins. Do not rely on code fallback for hosted envs. |
 | `STRIPE_SECRET_KEY` | Test mode | Live mode | Must match webhook/account environment. |
 | `STRIPE_WEBHOOK_SECRET` | Test endpoint | Live endpoint | Must match the deployed `stripe-webhook` endpoint. |
+| `STRIPE_MODE` | `test` | `live` | Webhooks whose `event.livemode` does not match are rejected before event claiming. |
+| `PAYMENTS_ENABLED` | `true` for rehearsals | `false` during cutover, then `true` at live-test window | Environment-level master switch for new Checkout Session creation. Keep live secrets in place for recovery/refunds. |
 | `NOTIFICATION_FROM_EMAIL` | Required for email | Required for email | Must use a verified sender/domain. |
 | `RESEND_API_KEY` | Test/staging key | Production key | Required for email notifications. |
 | `TWILIO_ACCOUNT_SID` | Test/staging account | Production account | Required for WhatsApp notifications if enabled. |
@@ -44,6 +46,7 @@ This is the May 2026 launch source of truth for environment parity. Do not commi
 | --- | --- | --- |
 | Stripe checkout success/cancel | Frontend origin in `ALLOWED_ORIGINS`; app returns to `/#/order/track`. | Same as staging with production app origin. |
 | Stripe webhook | Dashboard endpoint points to `/functions/v1/stripe-webhook`; secret matches `STRIPE_WEBHOOK_SECRET`. | Same with live endpoint and live secret. |
+| Admin payment switch | Admin dashboard `Payment controls` writes `app_settings.payment_controls`; checkout is enabled only when this and `PAYMENTS_ENABLED` are both on. | Same; use this first for curfew/operator stop-sale after the live window opens. |
 | WhatsApp status callback | Callback points to `/functions/v1/whatsapp-status-webhook`; token query matches `TWILIO_WEBHOOK_TOKEN` if configured. | Same with production Supabase URL. |
 | Resend webhook | Callback points to `/functions/v1/resend-email-webhook` if provider webhooks are enabled. | Same with production Supabase URL. |
 

--- a/docs/launch/checklist/incident-response.md
+++ b/docs/launch/checklist/incident-response.md
@@ -14,6 +14,7 @@ Check:
 Actions:
 
 - verify webhook secret and target endpoint
+- confirm `STRIPE_MODE` matches the Stripe event mode and the hosted endpoint secret is not a Stripe CLI listener secret
 - confirm the webhook function is deployed to the right project
 - inspect `stripe_processed_events.processing_status`, `attempt_count`, and `last_error`
 - use the admin `Reconcile Payment` action only after Stripe confirms the payment succeeded
@@ -73,6 +74,37 @@ Actions:
 
 - stop retrying from multiple places
 - capture the failing order IDs and reconcile them from one operator path
+
+### Checkout must be paused
+
+Actions:
+
+- first use the admin dashboard `Payment controls` card to pause buyer checkout and record the reason
+- set `PAYMENTS_ENABLED=false` if the admin dashboard is unavailable or checkout must be disabled at the environment level
+- do not swap production back to test Stripe keys after live orders exist
+- keep `stripe-webhook`, `stripe-refund`, and `stripe-reconcile-order` operating with live secrets
+- if intake must stop completely, expire open Stripe Checkout Sessions for affected pending orders and record the operator action
+
+Expected buyer behavior:
+
+- checkout returns a clear payment-paused message
+- the buyer is told no payment has been taken
+- the order remains retryable after payments are re-enabled
+
+### Stripe dispute created
+
+Check:
+
+- `audit_logs` entries with `event_type = stripe_dispute_created`
+- linked `orders.charge_id`
+- Stripe Dashboard dispute details
+
+Actions:
+
+- assign an owner immediately
+- inspect the linked order and fulfilment state
+- pause fulfilment or vendor release if needed
+- respond through Stripe Dashboard according to the dispute deadline
 
 ### Notification failures spike
 

--- a/docs/launch/checklist/pre-launch-gates.md
+++ b/docs/launch/checklist/pre-launch-gates.md
@@ -7,10 +7,14 @@ Do not treat an environment as launch-ready until all of the following are true:
 - auth posture is explicitly signed off
 - RLS audit is complete for buyer, seller, admin, and service-role boundaries
 - Vercel app vars, Supabase secrets, and Stripe keys all match the same environment pair
+- `STRIPE_MODE` matches the Stripe account mode and `PAYMENTS_ENABLED` starts false for production cutover until the live payment test window
+- admin dashboard `Payment controls` can pause buyer checkout after `PAYMENTS_ENABLED=true`; effective checkout requires both switches enabled
 - `ALLOWED_ORIGINS` is explicitly set for the target environment and hosted traffic is not relying on fallback origins in code
 - notification provider accounts, webhook endpoints, and template IDs are configured for the target environment
 - WhatsApp cost gates are explicitly configured: `WHATSAPP_SEND_MODE`, E.164 allowlist if required, daily cap, per-dispatch cap, and non-production live-mode override policy
 - one full buyer -> Stripe test-mode payment -> reconciliation -> vendor -> refund rehearsal has passed with a Stripe-onboarded seller account
+- Stripe checkout creation idempotency and existing-session reuse are verified so retry/double-tap requests do not create duplicate sessions
+- every visible launch vendor is verified in the live Stripe Dashboard; vendors that are not ready are hidden before go-live
 - Playwright smoke checks pass for public routes and configured role credentials
 - logging is sufficient to diagnose webhook, refund, notification, and auth failures
 - vendor onboarding has been rehearsed with the actual path you plan to use

--- a/docs/launch/deployment/edge-functions.md
+++ b/docs/launch/deployment/edge-functions.md
@@ -11,6 +11,7 @@ Current critical functions:
 - `stripe-webhook`
 - `order-transition`
 - `admin-store`
+- `payment-control`
 - `stripe-refund`
 - `stripe-reconcile-order`
 - `stripe-onboarding-link`

--- a/docs/launch/deployment/frontend-environment-variables.md
+++ b/docs/launch/deployment/frontend-environment-variables.md
@@ -23,8 +23,8 @@ Important current clarification:
 
 - use [Environment Matrix](../ENVIRONMENT_MATRIX.md) as the parity checklist before staging and production deploys
 
-- `VITE_STRIPE_PUBLIC_KEY` is still present in [`app/.env.example`](../../../app/.env.example)
-- the current app does not load Stripe.js or read `VITE_STRIPE_PUBLIC_KEY`
+- `VITE_STRIPE_PUBLIC_KEY` has been removed from [`app/.env.example`](../../../app/.env.example)
+- the current app does not load Stripe.js or read a frontend Stripe public key
 - checkout is redirect-based through the `stripe-checkout` edge function, so this variable is not currently required for runtime
 
 For the full inventory and rotation discipline, see [Secrets and Environment Inventory](../SECRETS.md).

--- a/docs/launch/deployment/stripe-configuration.md
+++ b/docs/launch/deployment/stripe-configuration.md
@@ -33,4 +33,11 @@ Important:
 
 - the webhook signing secret must come from the exact hosted Stripe webhook endpoint in use
 - do not mix Stripe CLI listener secrets with hosted endpoint secrets
+- set `STRIPE_MODE=test` for test-mode endpoints and `STRIPE_MODE=live` for live endpoints; mismatched `event.livemode` webhooks are rejected before event claiming
+- set `PAYMENTS_ENABLED=false` to pause only new Checkout Session creation while leaving live webhooks, refunds, reconciliation, disputes, and Connect status recovery available
+- `PAYMENTS_ENABLED` is the Supabase environment master switch; the admin portal `Payment controls` switch writes `app_settings.payment_controls` and can pause/resume checkout only when the master switch is `true`
+- live webhook endpoint API version must be pinned to `2023-10-16` while the edge functions remain on `stripe@14.x`
+- `stripe-checkout` reuses an existing open Checkout Session for an order and uses a Stripe idempotency key for new session creation
+- `account.updated` Connect events are matched to stores by `event.account` when present, otherwise by the account object's `id`
+- `charge.dispute.created` records an audit row and emits an alert-worthy warning for operator follow-up
 - seeded test seller accounts are not automatically Stripe-onboarded by the repo seeding scripts

--- a/docs/launch/deployment/supabase-function-secrets.md
+++ b/docs/launch/deployment/supabase-function-secrets.md
@@ -8,6 +8,8 @@ Core:
 
 - `STRIPE_SECRET_KEY`
 - `STRIPE_WEBHOOK_SECRET`
+- `STRIPE_MODE`
+- `PAYMENTS_ENABLED`
 - `SUPABASE_SERVICE_ROLE_KEY`
 - `ALLOWED_ORIGINS`
 
@@ -50,6 +52,13 @@ Notification outbox / retry tuning:
 Use [`supabase/.env.functions.example`](../../../supabase/.env.functions.example) as the template.
 
 Keep `supabase/.env.functions` local and untracked.
+
+Stripe live-cutover notes:
+
+- set `STRIPE_MODE=test` in staging and `STRIPE_MODE=live` in production
+- set `PAYMENTS_ENABLED=false` before production live-key cutover, then flip to `true` only when the controlled live payment window starts
+- after `PAYMENTS_ENABLED=true`, admins can pause/resume new checkout from the admin dashboard `Payment controls` card; this updates `app_settings.payment_controls` and does not change Stripe secrets
+- never disable live reconciliation/refund/webhook functions by swapping back to test Stripe keys after live orders exist
 
 Notes:
 

--- a/docs/launch/secrets/environment-surfaces.md
+++ b/docs/launch/secrets/environment-surfaces.md
@@ -8,7 +8,6 @@ Read this when you need the environment surfaces details from [Secrets and Envir
 | Vercel app | `VITE_SUPABASE_ANON_KEY` | Yes | Public key, but still environment-specific. |
 | Vercel app | `VITE_VENDOR_INVITE_CODE` | No for launch | Legacy invite-code vendor signup is not exposed in the May 2026 launch app. |
 | Vercel app | `VITE_SENTRY_DSN` | Recommended | Used by the browser app for Sentry error/reporting setup when present. |
-| Vercel app | `VITE_STRIPE_PUBLIC_KEY` | No | Present in `app/.env.example`, but the current app does not read it. Checkout is redirect-based through edge functions. |
 | Local operator scripts | `SUPABASE_SERVICE_ROLE_KEY` | Conditional | Used by `app/scripts/*.js` for seeding/admin scripting. Never expose this in browser runtime config. |
 | Local operator scripts | `VITE_SUPABASE_SERVICE_ROLE_KEY` | Legacy compatibility only | Some local scripts still accept this older name. Prefer `SUPABASE_SERVICE_ROLE_KEY`. |
 | Local operator scripts | `SUPABASE_URL` | Optional | Used by local scripts; set explicitly to avoid pointing at the wrong project. |
@@ -20,6 +19,8 @@ Read this when you need the environment surfaces details from [Secrets and Envir
 | Supabase functions | `SKIIP_ENVIRONMENT` | Recommended | Set to `staging`, `production`, or the active environment name. WhatsApp live mode is treated as non-production unless this resolves to `production` or `prod`. |
 | Supabase functions | `STRIPE_SECRET_KEY` | Yes | Required anywhere checkout, onboarding, refunds, or webhooks run. |
 | Supabase functions | `STRIPE_WEBHOOK_SECRET` | Yes | Must come from the exact hosted Stripe webhook endpoint in use. |
+| Supabase functions | `STRIPE_MODE` | Yes | Must be `test` or `live`. Stripe webhooks with mismatched `event.livemode` are rejected before event claiming. |
+| Supabase functions | `PAYMENTS_ENABLED` | Yes | Environment-level master switch. Only exact `true` allows new Checkout Session creation, and the admin payment switch must also be enabled. Keep `false` during production cutover until the live payment window. |
 | Supabase functions | `ALLOWED_ORIGINS` | Yes in hosted envs | Should always be set explicitly in staging and production. |
 | Supabase functions | `SENTRY_DSN` | Recommended | Read by the shared logger for edge-function error reporting if configured. |
 | Supabase functions | `RESEND_API_KEY` | Required for email | Required for customer email notifications in any environment that should send them. |
@@ -57,3 +58,4 @@ Read this when you need the environment surfaces details from [Secrets and Envir
 | Supabase functions | `NOTIFICATION_RETRY_BASE_DELAY_SECONDS` | Optional | Defaults to `60`. |
 | Supabase auth config | `auth.email.enable_confirmations` | Decision required | Repo config currently keeps it `false`, but signup UI copy still implies inbox verification. |
 | Stripe dashboard | Webhook endpoint + subscribed events | Yes | Keep staging and production endpoints separate. |
+| Supabase database | `app_settings.payment_controls` | Managed by migration/admin portal | Admin-facing checkout pause switch. Does not replace `PAYMENTS_ENABLED`; effective checkout requires both to be enabled. |

--- a/docs/roadmap/priority-1-current-gaps.md
+++ b/docs/roadmap/priority-1-current-gaps.md
@@ -42,7 +42,7 @@ These items most directly affect launch safety, payment correctness, security, a
   - Supabase secrets
   - Stripe accounts and webhook endpoints
   - notification providers
-- Decide whether `VITE_STRIPE_PUBLIC_KEY` should be removed from examples/docs or reintroduced through real Stripe.js usage.
+- Keep `VITE_STRIPE_PUBLIC_KEY` out of active Vercel/env examples unless real Stripe.js usage is deliberately reintroduced.
 - Fix or replace incomplete setup artifacts outside `docs/`, especially stale schema/setup references that can mislead operators.
 
 ### Testing and Fixtures

--- a/supabase/.env.functions.example
+++ b/supabase/.env.functions.example
@@ -1,6 +1,8 @@
 # Stripe
 STRIPE_SECRET_KEY=sk_test_or_live_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
+STRIPE_MODE=test
+PAYMENTS_ENABLED=true
 
 # Supabase
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -444,6 +444,11 @@ verify_jwt = false
 import_map = "./functions/stripe-reconcile-order/deno.json"
 entrypoint = "./functions/stripe-reconcile-order/index.ts"
 
+[functions.payment-control]
+enabled = true
+verify_jwt = false
+entrypoint = "./functions/payment-control/index.ts"
+
 [functions.whatsapp-notify]
 enabled = true
 verify_jwt = false

--- a/supabase/functions/_shared/payment-control.ts
+++ b/supabase/functions/_shared/payment-control.ts
@@ -1,0 +1,71 @@
+export const PAYMENT_CONTROLS_KEY = 'payment_controls'
+
+export interface PaymentControls {
+  enabled: boolean
+  reason: string | null
+  updatedAt: string | null
+  updatedBy: string | null
+}
+
+export const DEFAULT_PAYMENT_CONTROLS: PaymentControls = {
+  enabled: true,
+  reason: null,
+  updatedAt: null,
+  updatedBy: null,
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function normalizePaymentControls(value: unknown): PaymentControls {
+  if (!isObject(value)) {
+    return { ...DEFAULT_PAYMENT_CONTROLS }
+  }
+
+  return {
+    enabled: value.enabled !== false,
+    reason: typeof value.reason === 'string' && value.reason.trim()
+      ? value.reason.trim()
+      : null,
+    updatedAt: typeof value.updatedAt === 'string' && value.updatedAt
+      ? value.updatedAt
+      : null,
+    updatedBy: typeof value.updatedBy === 'string' && value.updatedBy
+      ? value.updatedBy
+      : null,
+  }
+}
+
+export async function getPaymentControls(supabase: any): Promise<PaymentControls> {
+  const { data, error } = await supabase
+    .from('app_settings')
+    .select('value')
+    .eq('key', PAYMENT_CONTROLS_KEY)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  return normalizePaymentControls(data?.value)
+}
+
+export function buildPaymentControlsUpdate({
+  enabled,
+  reason,
+  updatedBy,
+  updatedAt = new Date().toISOString(),
+}: {
+  enabled: boolean
+  reason?: string | null
+  updatedBy: string
+  updatedAt?: string
+}): PaymentControls {
+  return {
+    enabled,
+    reason: reason?.trim() || null,
+    updatedAt,
+    updatedBy,
+  }
+}

--- a/supabase/functions/_shared/stripe-checkout.ts
+++ b/supabase/functions/_shared/stripe-checkout.ts
@@ -1,0 +1,39 @@
+interface CheckoutOrderSnapshot {
+  id: string
+  checkout_session_id?: string | null
+  payment_failed_at?: string | null
+  payment_status?: string | null
+}
+
+interface CheckoutSessionSnapshot {
+  id?: string | null
+  status?: string | null
+  url?: string | null
+}
+
+function normalizeIdempotencyPart(value: string | null | undefined) {
+  return String(value || 'none').replace(/[^a-zA-Z0-9_.:-]/g, '_')
+}
+
+export function buildCheckoutSessionIdempotencyKey(order: CheckoutOrderSnapshot) {
+  const existingSessionPart = order.checkout_session_id || 'initial'
+  const attemptPart = order.payment_failed_at || order.payment_status || 'pending'
+
+  return [
+    'skiip-checkout',
+    normalizeIdempotencyPart(order.id),
+    normalizeIdempotencyPart(existingSessionPart),
+    normalizeIdempotencyPart(attemptPart),
+  ].join(':')
+}
+
+export function getReusableCheckoutSession(session: CheckoutSessionSnapshot | null | undefined) {
+  if (session?.id && session.status === 'open' && session.url) {
+    return {
+      sessionId: session.id,
+      url: session.url,
+    }
+  }
+
+  return null
+}

--- a/supabase/functions/_shared/stripe-config.ts
+++ b/supabase/functions/_shared/stripe-config.ts
@@ -1,0 +1,83 @@
+import Stripe from 'https://esm.sh/stripe@14.10.0'
+
+export const STRIPE_API_VERSION = '2023-10-16'
+
+export type StripeMode = 'test' | 'live'
+
+export interface EnvReader {
+  get(key: string): string | undefined | null
+}
+
+export class StripeModeMismatchError extends Error {
+  expectedMode: StripeMode
+  actualMode: StripeMode
+
+  constructor(expectedMode: StripeMode, actualMode: StripeMode) {
+    super(`Stripe event livemode mismatch: expected ${expectedMode}, received ${actualMode}`)
+    this.name = 'StripeModeMismatchError'
+    this.expectedMode = expectedMode
+    this.actualMode = actualMode
+  }
+}
+
+export function getRequiredStripeMode(env: EnvReader = Deno.env): StripeMode {
+  const rawMode = env.get('STRIPE_MODE')?.trim().toLowerCase()
+
+  if (rawMode === 'test' || rawMode === 'live') {
+    return rawMode
+  }
+
+  throw new Error('STRIPE_MODE must be set to "test" or "live"')
+}
+
+export function assertStripeLivemode(
+  event: { livemode: boolean },
+  env: EnvReader = Deno.env,
+) {
+  const expectedMode = getRequiredStripeMode(env)
+  const expectedLivemode = expectedMode === 'live'
+
+  if (event.livemode !== expectedLivemode) {
+    throw new StripeModeMismatchError(expectedMode, event.livemode ? 'live' : 'test')
+  }
+}
+
+export function isPaymentsEnabled(env: EnvReader = Deno.env) {
+  return env.get('PAYMENTS_ENABLED')?.trim().toLowerCase() === 'true'
+}
+
+export function parseStripeWebhookSecrets(env: EnvReader = Deno.env) {
+  return (env.get('STRIPE_WEBHOOK_SECRET') || '')
+    .split(',')
+    .map((secret) => secret.trim())
+    .filter(Boolean)
+}
+
+export async function constructWithWebhookSecrets<T>(
+  secrets: string[],
+  construct: (secret: string) => Promise<T>,
+  getErrorMessage: (error: unknown) => string = (error) =>
+    error instanceof Error ? error.message : String(error),
+) {
+  if (!secrets.length) {
+    throw new Error('STRIPE_WEBHOOK_SECRET is not configured')
+  }
+
+  const errors: string[] = []
+  for (const secret of secrets) {
+    try {
+      return await construct(secret)
+    } catch (error: unknown) {
+      errors.push(getErrorMessage(error))
+    }
+  }
+
+  throw new Error(errors[0] || 'Stripe webhook signature verification failed')
+}
+
+export function createStripeClient(secretKey: string) {
+  return new Stripe(secretKey, {
+    apiVersion: STRIPE_API_VERSION,
+    httpClient: Stripe.createFetchHttpClient(),
+  })
+}

--- a/supabase/functions/_shared/stripe-webhook-events.ts
+++ b/supabase/functions/_shared/stripe-webhook-events.ts
@@ -1,0 +1,94 @@
+export interface AuditLogger {
+  warn(message: string, context?: Record<string, unknown>): void
+}
+
+export interface StripeConnectEventLike {
+  account?: string | null
+}
+
+export interface StripeAccountLikeWithId {
+  id?: string | null
+}
+
+export function getStripeConnectAccountId(
+  event: StripeConnectEventLike,
+  account: StripeAccountLikeWithId,
+) {
+  return event.account || account.id || null
+}
+
+export function getStripeObjectId(value: unknown) {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (value && typeof value === 'object' && 'id' in value) {
+    const id = (value as { id?: unknown }).id
+    return typeof id === 'string' ? id : null
+  }
+
+  return null
+}
+
+export async function handleStripeDisputeCreated({
+  supabase,
+  dispute,
+  eventId,
+  log,
+}: {
+  supabase: any
+  dispute: {
+    id: string
+    charge?: unknown
+    amount?: number | null
+    currency?: string | null
+    reason?: string | null
+    status?: string | null
+  }
+  eventId: string
+  log: AuditLogger
+}) {
+  const chargeId = getStripeObjectId(dispute.charge)
+  let orderId: string | null = null
+
+  if (chargeId) {
+    const { data, error } = await supabase
+      .from('orders')
+      .select('id')
+      .eq('charge_id', chargeId)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+
+    orderId = data?.id || null
+  }
+
+  const payload = {
+    dispute_id: dispute.id,
+    charge_id: chargeId,
+    order_id: orderId,
+    amount: typeof dispute.amount === 'number' ? dispute.amount / 100 : null,
+    currency: dispute.currency || null,
+    reason: dispute.reason || null,
+    status: dispute.status || null,
+    stripe_event_id: eventId,
+  }
+
+  log.warn('Stripe dispute created', payload)
+
+  const { error } = await supabase.from('audit_logs').insert({
+    event_type: 'stripe_dispute_created',
+    entity_type: orderId ? 'order' : 'stripe_dispute',
+    entity_id: orderId,
+    actor_role: 'system',
+    payload,
+  })
+
+  if (error) {
+    throw error
+  }
+
+  return payload
+}

--- a/supabase/functions/payment-control/index.ts
+++ b/supabase/functions/payment-control/index.ts
@@ -1,0 +1,113 @@
+import "https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts"
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { buildCorsHeaders, isAllowedOrigin, jsonResponse } from "../_shared/http.ts"
+import { getAuthErrorStatus, requireUser } from "../_shared/auth.ts"
+import { createServiceClient } from "../_shared/service.ts"
+import { logger } from "../_shared/logger.ts"
+import { isPaymentsEnabled } from "../_shared/stripe-config.ts"
+import {
+  buildPaymentControlsUpdate,
+  getPaymentControls,
+  PAYMENT_CONTROLS_KEY,
+} from "../_shared/payment-control.ts"
+
+const log = logger('payment-control')
+
+interface PaymentControlRequest {
+  action?: 'get' | 'set'
+  enabled?: boolean
+  reason?: string | null
+}
+
+function buildResponse(controls: Awaited<ReturnType<typeof getPaymentControls>>) {
+  const masterEnabled = isPaymentsEnabled()
+  return {
+    controls,
+    masterEnabled,
+    checkoutEnabled: masterEnabled && controls.enabled,
+  }
+}
+
+serve(async (req: Request) => {
+  const origin = req.headers.get('origin')
+  const corsHeaders = buildCorsHeaders(origin)
+
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405, origin)
+  }
+
+  if (!isAllowedOrigin(origin)) {
+    log.warn('Rejected request from disallowed origin', { origin })
+    return jsonResponse({ error: 'Origin not allowed' }, 403, origin)
+  }
+
+  try {
+    const user = await requireUser(req)
+    if (user.role !== 'admin') {
+      return jsonResponse({ error: 'Forbidden' }, 403, origin)
+    }
+
+    const body = (await req.json().catch(() => ({}))) as PaymentControlRequest
+    const action = body.action || 'get'
+    const supabase = createServiceClient()
+
+    if (action === 'get') {
+      const controls = await getPaymentControls(supabase)
+      return jsonResponse(buildResponse(controls), 200, origin)
+    }
+
+    if (action !== 'set') {
+      return jsonResponse({ error: 'Invalid payment control action' }, 400, origin)
+    }
+
+    if (typeof body.enabled !== 'boolean') {
+      return jsonResponse({ error: 'enabled must be a boolean' }, 400, origin)
+    }
+
+    const controls = buildPaymentControlsUpdate({
+      enabled: body.enabled,
+      reason: body.reason,
+      updatedBy: user.id,
+    })
+
+    const { data, error } = await supabase
+      .from('app_settings')
+      .upsert({ key: PAYMENT_CONTROLS_KEY, value: controls }, { onConflict: 'key' })
+      .select('value')
+      .single()
+
+    if (error) {
+      throw error
+    }
+
+    await supabase.from('audit_logs').insert({
+      event_type: 'payment_controls_updated',
+      entity_type: 'app_setting',
+      entity_id: null,
+      actor_user_id: user.id,
+      actor_role: user.role,
+      payload: {
+        key: PAYMENT_CONTROLS_KEY,
+        enabled: controls.enabled,
+        reason: controls.reason,
+      },
+    })
+
+    return jsonResponse(buildResponse(data?.value || controls), 200, origin)
+  } catch (err: unknown) {
+    const error = err as Error
+    log.error('Payment control operation failed', {
+      error: error.message,
+      stack: error.stack,
+    })
+    return jsonResponse(
+      { error: error.message || 'Payment control operation failed' },
+      getAuthErrorStatus(err) || 400,
+      origin,
+    )
+  }
+})

--- a/supabase/functions/stripe-checkout/index.ts
+++ b/supabase/functions/stripe-checkout/index.ts
@@ -1,10 +1,15 @@
 import "https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts"
-import Stripe from 'https://esm.sh/stripe@14.10.0'
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { buildCorsHeaders, isAllowedOrigin, isAllowedRedirectUrl, jsonResponse } from "../_shared/http.ts"
 import { getAuthErrorStatus, requireUser } from "../_shared/auth.ts"
 import { createServiceClient } from "../_shared/service.ts"
 import { logger } from "../_shared/logger.ts"
+import { createStripeClient, isPaymentsEnabled } from "../_shared/stripe-config.ts"
+import {
+  buildCheckoutSessionIdempotencyKey,
+  getReusableCheckoutSession,
+} from "../_shared/stripe-checkout.ts"
+import { getPaymentControls } from "../_shared/payment-control.ts"
 
 const log = logger('stripe-checkout')
 const PLATFORM_FEE_PERCENT = 0.10
@@ -14,9 +19,7 @@ if (!stripeSecretKey) {
   throw new Error('Missing STRIPE_SECRET_KEY environment variable')
 }
 
-const stripe = new Stripe(stripeSecretKey, {
-  httpClient: Stripe.createFetchHttpClient(),
-})
+const stripe = createStripeClient(stripeSecretKey)
 
 interface CheckoutRequest {
   orderDetails: {
@@ -44,6 +47,18 @@ serve(async (req: Request) => {
 
   try {
     const user = await requireUser(req)
+
+    if (!isPaymentsEnabled()) {
+      return jsonResponse(
+        {
+          error: 'PAYMENTS_PAUSED',
+          message: 'Payments are temporarily unavailable. No payment has been taken.',
+        },
+        503,
+        origin,
+      )
+    }
+
     const body = (await req.json()) as CheckoutRequest
     const orderId = body.orderDetails?.order_id
     const returnUrl = body.returnUrl
@@ -53,9 +68,22 @@ serve(async (req: Request) => {
     }
 
     const supabase = createServiceClient()
+    const paymentControls = await getPaymentControls(supabase)
+
+    if (!paymentControls.enabled) {
+      return jsonResponse(
+        {
+          error: 'PAYMENTS_PAUSED',
+          message: 'Payments are temporarily unavailable. No payment has been taken.',
+        },
+        503,
+        origin,
+      )
+    }
+
     const { data: order, error: orderError } = await supabase
       .from('orders')
-      .select('id, user_id, store_id, subtotal, total, tip_amount, service_fee, status, payment_status')
+      .select('id, user_id, store_id, subtotal, total, tip_amount, service_fee, status, payment_status, checkout_session_id, payment_failed_at')
       .eq('id', orderId)
       .single()
 
@@ -130,6 +158,27 @@ serve(async (req: Request) => {
       return jsonResponse({ error: 'Order item quantity is invalid' }, 409, origin)
     }
 
+    if (order.checkout_session_id) {
+      try {
+        const existingSession = await stripe.checkout.sessions.retrieve(order.checkout_session_id)
+        const reusableSession = getReusableCheckoutSession(existingSession)
+
+        if (reusableSession) {
+          log.info('Reusing open Stripe Checkout Session', {
+            orderId,
+            checkoutSessionId: reusableSession.sessionId,
+          })
+          return jsonResponse(reusableSession, 200, origin)
+        }
+      } catch (error: unknown) {
+        log.warn('Existing Stripe Checkout Session could not be reused', {
+          orderId,
+          checkoutSessionId: order.checkout_session_id,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
     const lineItems = orderItems.map((item) => ({
       price_data: {
         currency: 'gbp',
@@ -185,6 +234,8 @@ serve(async (req: Request) => {
           store_id: order.store_id,
         },
       },
+    }, {
+      idempotencyKey: buildCheckoutSessionIdempotencyKey(order),
     })
 
     const { error: updateError } = await supabase

--- a/supabase/functions/stripe-connect-status/index.ts
+++ b/supabase/functions/stripe-connect-status/index.ts
@@ -1,5 +1,4 @@
 import "https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts"
-import Stripe from 'https://esm.sh/stripe@14.10.0'
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { buildCorsHeaders, isAllowedOrigin, jsonResponse } from "../_shared/http.ts"
 import { getAuthErrorStatus, requireUser } from "../_shared/auth.ts"
@@ -10,6 +9,7 @@ import {
   canReconcileStripeConnectStore,
   deriveStripeConnectStatus,
 } from "../_shared/stripe-connect-status.ts"
+import { createStripeClient } from "../_shared/stripe-config.ts"
 
 const log = logger('stripe-connect-status')
 
@@ -18,9 +18,7 @@ if (!stripeSecretKey) {
   throw new Error('Missing STRIPE_SECRET_KEY environment variable')
 }
 
-const stripe = new Stripe(stripeSecretKey, {
-  httpClient: Stripe.createFetchHttpClient(),
-})
+const stripe = createStripeClient(stripeSecretKey)
 
 interface ConnectStatusRequest {
   store_id?: string
@@ -86,20 +84,22 @@ serve(async (req: Request) => {
       return jsonResponse({ error: 'Store not found' }, 404, origin)
     }
 
-    if (!canReconcileStripeConnectStore(user, store)) {
+    const storeRecord = store as any
+
+    if (!canReconcileStripeConnectStore(user, storeRecord)) {
       return jsonResponse({ error: 'Forbidden' }, 403, origin)
     }
 
-    const account = store.stripe_account_id
-      ? await stripe.accounts.retrieve(store.stripe_account_id)
+    const account = storeRecord.stripe_account_id
+      ? await stripe.accounts.retrieve(storeRecord.stripe_account_id)
       : null
     const derivedStatus = deriveStripeConnectStatus(account)
-    const update = buildStripeConnectStoreUpdate(store, derivedStatus)
+    const update = buildStripeConnectStoreUpdate(storeRecord, derivedStatus)
 
     const { data: updatedStore, error: updateError } = await supabase
       .from('stores')
       .update(update)
-      .eq('id', store.id)
+      .eq('id', storeRecord.id)
       .select(STORE_STATUS_SELECT)
       .single()
 

--- a/supabase/functions/stripe-onboarding-link/index.ts
+++ b/supabase/functions/stripe-onboarding-link/index.ts
@@ -1,5 +1,4 @@
 import "https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts"
-import Stripe from 'https://esm.sh/stripe@14.10.0'
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { logger } from "../_shared/logger.ts"
@@ -9,6 +8,7 @@ import {
   buildStripeConnectStoreUpdate,
   deriveStripeConnectStatus,
 } from "../_shared/stripe-connect-status.ts"
+import { createStripeClient } from "../_shared/stripe-config.ts"
 
 const log = logger('stripe-onboarding-link')
 
@@ -17,9 +17,7 @@ if (!stripeSecretKey) {
   throw new Error('Missing STRIPE_SECRET_KEY environment variable')
 }
 
-const stripe = new Stripe(stripeSecretKey, {
-  httpClient: Stripe.createFetchHttpClient(),
-})
+const stripe = createStripeClient(stripeSecretKey)
 
 interface OnboardingRequest {
   store_id: string
@@ -106,7 +104,7 @@ serve(async (req: Request) => {
       stripeAccountId = account.id
 
       const derivedStatus = deriveStripeConnectStatus(account)
-      const statusUpdate = buildStripeConnectStoreUpdate(store, derivedStatus)
+      const statusUpdate = buildStripeConnectStoreUpdate({}, derivedStatus)
 
       const { error: updateError } = await supabase
         .from('stores')

--- a/supabase/functions/stripe-reconcile-order/index.ts
+++ b/supabase/functions/stripe-reconcile-order/index.ts
@@ -11,6 +11,7 @@ import {
   buildPaymentReconciliation,
   retrievePaymentIntentWithCharge,
 } from "../_shared/stripe-reconciliation.ts"
+import { createStripeClient } from "../_shared/stripe-config.ts"
 
 const log = logger('stripe-reconcile-order')
 
@@ -19,9 +20,7 @@ if (!stripeSecretKey) {
   throw new Error('Missing STRIPE_SECRET_KEY environment variable')
 }
 
-const stripe = new Stripe(stripeSecretKey, {
-  httpClient: Stripe.createFetchHttpClient(),
-})
+const stripe = createStripeClient(stripeSecretKey)
 
 interface ReconcileOrderRequest {
   orderId?: string

--- a/supabase/functions/stripe-refund/index.ts
+++ b/supabase/functions/stripe-refund/index.ts
@@ -1,11 +1,11 @@
 import "https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts"
-import Stripe from 'https://esm.sh/stripe@14.10.0'
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { buildCorsHeaders, isAllowedOrigin, jsonResponse } from "../_shared/http.ts"
 import { getAuthErrorStatus, requireUser } from "../_shared/auth.ts"
 import { createServiceClient } from "../_shared/service.ts"
 import { logger } from "../_shared/logger.ts"
 import { sendTransactionalNotificationsBestEffort } from "../_shared/notifications.ts"
+import { createStripeClient } from "../_shared/stripe-config.ts"
 
 const log = logger('stripe-refund')
 
@@ -14,9 +14,7 @@ if (!stripeSecretKey) {
   throw new Error('Missing STRIPE_SECRET_KEY environment variable')
 }
 
-const stripe = new Stripe(stripeSecretKey, {
-  httpClient: Stripe.createFetchHttpClient(),
-})
+const stripe = createStripeClient(stripeSecretKey)
 
 interface RefundRequest {
   orderId: string

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -13,6 +13,16 @@ import {
   buildStripeConnectStoreUpdate,
   deriveStripeConnectStatus,
 } from "../_shared/stripe-connect-status.ts"
+import {
+  assertStripeLivemode,
+  constructWithWebhookSecrets,
+  createStripeClient,
+  parseStripeWebhookSecrets,
+} from "../_shared/stripe-config.ts"
+import {
+  getStripeConnectAccountId,
+  handleStripeDisputeCreated,
+} from "../_shared/stripe-webhook-events.ts"
 
 const log = logger('stripe-webhook')
 
@@ -21,18 +31,9 @@ if (!stripeSecretKey) {
   throw new Error('Missing STRIPE_SECRET_KEY environment variable')
 }
 
-const stripe = new Stripe(stripeSecretKey, {
-  httpClient: Stripe.createFetchHttpClient(),
-})
+const stripe = createStripeClient(stripeSecretKey)
 
-function parseWebhookSecrets() {
-  return (Deno.env.get('STRIPE_WEBHOOK_SECRET') || '')
-    .split(',')
-    .map((secret) => secret.trim())
-    .filter(Boolean)
-}
-
-const endpointSecrets = parseWebhookSecrets()
+const endpointSecrets = parseStripeWebhookSecrets()
 
 interface WebhookClaim {
   should_process: boolean
@@ -150,21 +151,12 @@ async function recordAuditLog(supabase: any, row: Record<string, unknown>) {
   }
 }
 
-async function constructStripeEvent(body: string, signature: string) {
-  if (!endpointSecrets.length) {
-    throw new Error('STRIPE_WEBHOOK_SECRET is not configured')
-  }
-
-  const errors: string[] = []
-  for (const secret of endpointSecrets) {
-    try {
-      return await stripe.webhooks.constructEventAsync(body, signature, secret)
-    } catch (error: unknown) {
-      errors.push(getErrorMessage(error))
-    }
-  }
-
-  throw new Error(errors[0] || 'Stripe webhook signature verification failed')
+async function constructStripeEvent(body: string, signature: string): Promise<Stripe.Event> {
+  return await constructWithWebhookSecrets<Stripe.Event>(
+    endpointSecrets,
+    (secret) => stripe.webhooks.constructEventAsync(body, signature, secret),
+    getErrorMessage,
+  )
 }
 
 async function handleCheckoutSessionCompleted(supabase: any, event: Stripe.Event) {
@@ -460,10 +452,19 @@ async function handleStripeEvent(supabase: any, event: Stripe.Event) {
     await handlePaymentIntentFailed(supabase, event)
   } else if (event.type === 'account.updated') {
     const account = event.data.object as Stripe.Account
+    const stripeAccountId = getStripeConnectAccountId(event, account)
+
+    if (!stripeAccountId) {
+      log.warn('Account update ignored because the Stripe account id is missing', {
+        eventId: event.id,
+      })
+      return
+    }
+
     const { data: store, error: storeLookupError } = await supabase
       .from('stores')
       .select(STORE_CONNECT_STATUS_SELECT)
-      .eq('stripe_account_id', account.id)
+      .eq('stripe_account_id', stripeAccountId)
       .maybeSingle()
 
     if (storeLookupError) {
@@ -472,7 +473,9 @@ async function handleStripeEvent(supabase: any, event: Stripe.Event) {
 
     if (!store) {
       log.warn('Account update ignored because no store has this Stripe account', {
-        accountId: account.id,
+        accountId: stripeAccountId,
+        eventAccount: event.account || null,
+        objectAccountId: account.id || null,
       })
       return
     }
@@ -508,7 +511,12 @@ async function handleStripeEvent(supabase: any, event: Stripe.Event) {
     }
   } else if (event.type === 'charge.dispute.created') {
     const dispute = event.data.object as Stripe.Dispute
-    log.warn(`Dispute created: ${dispute.id} for charge ${dispute.charge}`)
+    await handleStripeDisputeCreated({
+      supabase,
+      dispute,
+      eventId: event.id,
+      log,
+    })
   }
 }
 
@@ -538,6 +546,8 @@ serve(async (req: Request) => {
     const event = await constructStripeEvent(body, signature)
     eventId = event.id
     eventType = event.type
+    assertStripeLivemode(event)
+
     const supabase = createServiceClient()
     const claim = await claimWebhookEvent(supabase, event)
 
@@ -567,6 +577,7 @@ serve(async (req: Request) => {
     return new Response(JSON.stringify({ ok: true }), { status: 200 })
   } catch (error: unknown) {
     const errorMessage = getErrorMessage(error)
+
     log.error(`Webhook processing failed: ${errorMessage}`, {
       eventId,
       eventType,

--- a/supabase/functions/tests/payment-control-test.ts
+++ b/supabase/functions/tests/payment-control-test.ts
@@ -1,0 +1,119 @@
+import {
+  assertEquals,
+  assertRejects,
+} from "jsr:@std/assert@1";
+import {
+  buildPaymentControlsUpdate,
+  getPaymentControls,
+  normalizePaymentControls,
+  PAYMENT_CONTROLS_KEY,
+} from "../_shared/payment-control.ts";
+
+function fakeSettingsClient(result: {
+  data?: { value?: unknown } | null;
+  error?: Error | null;
+}) {
+  const calls: Array<{ table: string; key: string; value: string }> = [];
+
+  return {
+    calls,
+    from(table: string) {
+      return {
+        select() {
+          return this;
+        },
+        eq(key: string, value: string) {
+          calls.push({ table, key, value });
+          return this;
+        },
+        async maybeSingle() {
+          return {
+            data: result.data ?? null,
+            error: result.error ?? null,
+          };
+        },
+      };
+    },
+  };
+}
+
+Deno.test("normalizePaymentControls defaults checkout to enabled", () => {
+  assertEquals(normalizePaymentControls(null), {
+    enabled: true,
+    reason: null,
+    updatedAt: null,
+    updatedBy: null,
+  });
+
+  assertEquals(normalizePaymentControls({ enabled: "false" }), {
+    enabled: true,
+    reason: null,
+    updatedAt: null,
+    updatedBy: null,
+  });
+});
+
+Deno.test("normalizePaymentControls preserves an explicit admin pause", () => {
+  assertEquals(
+    normalizePaymentControls({
+      enabled: false,
+      reason: " Curfew ",
+      updatedAt: "2026-05-25T14:00:00.000Z",
+      updatedBy: "admin-user",
+    }),
+    {
+      enabled: false,
+      reason: "Curfew",
+      updatedAt: "2026-05-25T14:00:00.000Z",
+      updatedBy: "admin-user",
+    },
+  );
+});
+
+Deno.test("buildPaymentControlsUpdate records the operator and timestamp", () => {
+  assertEquals(
+    buildPaymentControlsUpdate({
+      enabled: false,
+      reason: " Incident stop-sale ",
+      updatedBy: "admin-user",
+      updatedAt: "2026-05-25T14:05:00.000Z",
+    }),
+    {
+      enabled: false,
+      reason: "Incident stop-sale",
+      updatedAt: "2026-05-25T14:05:00.000Z",
+      updatedBy: "admin-user",
+    },
+  );
+});
+
+Deno.test("getPaymentControls reads the payment_controls app setting", async () => {
+  const supabase = fakeSettingsClient({
+    data: {
+      value: {
+        enabled: false,
+        reason: "Curfew",
+      },
+    },
+  });
+
+  assertEquals(await getPaymentControls(supabase), {
+    enabled: false,
+    reason: "Curfew",
+    updatedAt: null,
+    updatedBy: null,
+  });
+  assertEquals(supabase.calls, [{
+    table: "app_settings",
+    key: "key",
+    value: PAYMENT_CONTROLS_KEY,
+  }]);
+});
+
+Deno.test("getPaymentControls surfaces database errors", async () => {
+  await assertRejects(
+    () => getPaymentControls(fakeSettingsClient({ error: new Error("db unavailable") })),
+    Error,
+    "db unavailable",
+  );
+});

--- a/supabase/functions/tests/stripe-checkout-test.ts
+++ b/supabase/functions/tests/stripe-checkout-test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import {
+  buildCheckoutSessionIdempotencyKey,
+  getReusableCheckoutSession,
+} from "../_shared/stripe-checkout.ts";
+
+Deno.test("buildCheckoutSessionIdempotencyKey is stable for a pending order", () => {
+  assertEquals(
+    buildCheckoutSessionIdempotencyKey({
+      id: "order_123",
+      payment_status: "pending",
+      checkout_session_id: null,
+      payment_failed_at: null,
+    }),
+    "skiip-checkout:order_123:initial:pending",
+  );
+});
+
+Deno.test("buildCheckoutSessionIdempotencyKey changes after a failed payment attempt", () => {
+  assertEquals(
+    buildCheckoutSessionIdempotencyKey({
+      id: "order_123",
+      checkout_session_id: "cs_test_123",
+      payment_failed_at: "2026-05-25T13:00:00.000Z",
+    }),
+    "skiip-checkout:order_123:cs_test_123:2026-05-25T13:00:00.000Z",
+  );
+});
+
+Deno.test("getReusableCheckoutSession only reuses open sessions with URLs", () => {
+  assertEquals(
+    getReusableCheckoutSession({
+      id: "cs_test_open",
+      status: "open",
+      url: "https://checkout.stripe.com/c/pay/cs_test_open",
+    }),
+    {
+      sessionId: "cs_test_open",
+      url: "https://checkout.stripe.com/c/pay/cs_test_open",
+    },
+  );
+
+  assertEquals(
+    getReusableCheckoutSession({
+      id: "cs_test_complete",
+      status: "complete",
+      url: "https://checkout.stripe.com/c/pay/cs_test_complete",
+    }),
+    null,
+  );
+
+  assertEquals(
+    getReusableCheckoutSession({
+      id: "cs_test_open",
+      status: "open",
+      url: null,
+    }),
+    null,
+  );
+});

--- a/supabase/functions/tests/stripe-config-test.ts
+++ b/supabase/functions/tests/stripe-config-test.ts
@@ -1,0 +1,102 @@
+import {
+  assertEquals,
+  assertThrows,
+  assertRejects,
+} from "jsr:@std/assert@1";
+import {
+  assertStripeLivemode,
+  constructWithWebhookSecrets,
+  getRequiredStripeMode,
+  isPaymentsEnabled,
+  parseStripeWebhookSecrets,
+  StripeModeMismatchError,
+} from "../_shared/stripe-config.ts";
+
+function env(values: Record<string, string | undefined>) {
+  return {
+    get(key: string) {
+      return values[key];
+    },
+  };
+}
+
+Deno.test("getRequiredStripeMode requires an explicit mode", () => {
+  assertThrows(
+    () => getRequiredStripeMode(env({})),
+    Error,
+    'STRIPE_MODE must be set to "test" or "live"',
+  );
+
+  assertThrows(
+    () => getRequiredStripeMode(env({ STRIPE_MODE: "sandbox" })),
+    Error,
+    'STRIPE_MODE must be set to "test" or "live"',
+  );
+});
+
+Deno.test("assertStripeLivemode rejects mismatched test and live events", () => {
+  assertStripeLivemode({ livemode: false }, env({ STRIPE_MODE: "test" }));
+  assertStripeLivemode({ livemode: true }, env({ STRIPE_MODE: "live" }));
+
+  const testModeError = assertThrows(
+    () => assertStripeLivemode({ livemode: true }, env({ STRIPE_MODE: "test" })),
+    StripeModeMismatchError,
+  );
+  assertEquals(testModeError.expectedMode, "test");
+  assertEquals(testModeError.actualMode, "live");
+
+  const liveModeError = assertThrows(
+    () => assertStripeLivemode({ livemode: false }, env({ STRIPE_MODE: "live" })),
+    StripeModeMismatchError,
+  );
+  assertEquals(liveModeError.expectedMode, "live");
+  assertEquals(liveModeError.actualMode, "test");
+});
+
+Deno.test("isPaymentsEnabled only accepts exact true", () => {
+  assertEquals(isPaymentsEnabled(env({ PAYMENTS_ENABLED: "true" })), true);
+  assertEquals(isPaymentsEnabled(env({ PAYMENTS_ENABLED: "TRUE" })), true);
+  assertEquals(isPaymentsEnabled(env({ PAYMENTS_ENABLED: "false" })), false);
+  assertEquals(isPaymentsEnabled(env({ PAYMENTS_ENABLED: "yes" })), false);
+  assertEquals(isPaymentsEnabled(env({})), false);
+});
+
+Deno.test("parseStripeWebhookSecrets supports comma-separated rotation secrets", () => {
+  assertEquals(
+    parseStripeWebhookSecrets(env({
+      STRIPE_WEBHOOK_SECRET: " whsec_old ,whsec_new,, ",
+    })),
+    ["whsec_old", "whsec_new"],
+  );
+});
+
+Deno.test("constructWithWebhookSecrets attempts rotated secrets until one verifies", async () => {
+  const attempted: string[] = [];
+  const event = await constructWithWebhookSecrets(
+    ["whsec_old", "whsec_new"],
+    async (secret) => {
+      attempted.push(secret);
+      if (secret === "whsec_new") {
+        return { id: "evt_123" };
+      }
+      throw new Error("Invalid signature");
+    },
+  );
+
+  assertEquals(attempted, ["whsec_old", "whsec_new"]);
+  assertEquals(event, { id: "evt_123" });
+});
+
+Deno.test("constructWithWebhookSecrets reports the first verification failure", async () => {
+  await assertRejects(
+    () =>
+      constructWithWebhookSecrets(
+        ["whsec_old", "whsec_new"],
+        async (secret) => {
+          throw new Error(`${secret} failed`);
+        },
+      ),
+    Error,
+    "whsec_old failed",
+  );
+});

--- a/supabase/functions/tests/stripe-webhook-events-test.ts
+++ b/supabase/functions/tests/stripe-webhook-events-test.ts
@@ -1,0 +1,82 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import {
+  getStripeConnectAccountId,
+  handleStripeDisputeCreated,
+} from "../_shared/stripe-webhook-events.ts";
+
+function createFakeSupabase(orderId: string | null) {
+  const auditRows: Record<string, unknown>[] = [];
+
+  return {
+    auditRows,
+    from(table: string) {
+      if (table === "orders") {
+        return {
+          select() {
+            return this;
+          },
+          eq() {
+            return this;
+          },
+          async maybeSingle() {
+            return { data: orderId ? { id: orderId } : null, error: null };
+          },
+        };
+      }
+
+      if (table === "audit_logs") {
+        return {
+          async insert(row: Record<string, unknown>) {
+            auditRows.push(row);
+            return { error: null };
+          },
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  };
+}
+
+Deno.test("getStripeConnectAccountId prefers the Connect event account owner", () => {
+  assertEquals(
+    getStripeConnectAccountId({ account: "acct_connected" }, { id: "acct_object" }),
+    "acct_connected",
+  );
+
+  assertEquals(
+    getStripeConnectAccountId({}, { id: "acct_object" }),
+    "acct_object",
+  );
+});
+
+Deno.test("handleStripeDisputeCreated writes an audit row for the linked order", async () => {
+  const supabase = createFakeSupabase("order_123");
+  const warnings: Record<string, unknown>[] = [];
+
+  const payload = await handleStripeDisputeCreated({
+    supabase,
+    dispute: {
+      id: "dp_123",
+      charge: "ch_123",
+      amount: 1200,
+      currency: "gbp",
+      reason: "fraudulent",
+      status: "needs_response",
+    },
+    eventId: "evt_123",
+    log: {
+      warn(_message, context) {
+        warnings.push(context || {});
+      },
+    },
+  });
+
+  assertEquals(payload.order_id, "order_123");
+  assertEquals(payload.amount, 12);
+  assertEquals(warnings.length, 1);
+  assertEquals(supabase.auditRows.length, 1);
+  assertEquals(supabase.auditRows[0].event_type, "stripe_dispute_created");
+  assertEquals(supabase.auditRows[0].entity_type, "order");
+  assertEquals(supabase.auditRows[0].entity_id, "order_123");
+});

--- a/supabase/migrations/20260525142211_payment_controls.sql
+++ b/supabase/migrations/20260525142211_payment_controls.sql
@@ -1,0 +1,15 @@
+-- Payment controls for live launch operations.
+-- PAYMENTS_ENABLED remains the environment-level master switch.
+-- This app setting lets admins pause buyer checkout without changing secrets.
+
+INSERT INTO public.app_settings (key, value)
+VALUES (
+    'payment_controls',
+    jsonb_build_object(
+        'enabled', true,
+        'reason', NULL,
+        'updatedAt', NULL,
+        'updatedBy', NULL
+    )
+)
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary
- add live Stripe mode/payment pause guards and webhook mode validation
- add admin checkout pause control backed by Supabase app_settings
- deploy-focused docs/tests for Stripe live cutover readiness

## Verification
- deno check touched Supabase functions
- deno test --allow-env supabase/functions/tests/*.ts
- npm run test
- npm run build
- remote Supabase migration/function/secret verification completed