### PR TITLE
[codex] add Supabase password recovery flow

### DIFF
--- a/PHASE6.md
+++ b/PHASE6.md
@@ -11,7 +11,8 @@ Historical progress logs:
 | :--- | :--- | :--- | :--- |
 | Dean Gibson | ~0.5 hours | 2026/05/24 | Phase 6 tracking rollover. Capped the Phase 5 progress log, moved Phase 1-5 progress history into `docs/`, and created `PHASE6.md` as the active root tracker for new work. |
 | Dean Gibson | ~2.5 hours | 2026/05/25 | Admin portal operational restructure hotfix. Split admin overview, orders, vendor performance, event setup, and checkout settings into focused routed surfaces; added action-path test coverage and updated active operations/launch documentation. Added local lint, Vitest, build, route-protection smoke, and visual-layout evidence; authenticated operational action verification remains a draft-PR merge gate. |
-| **TOTAL** | **~3.0 hours** | | |
+| Dean Gibson | ~0.75 hours | 2026/05/25 | Added Supabase PKCE password recovery for existing accounts: reset-request and password-update screens, recovery-event guard, unified login link, hash-routed callback support, focused tests, and deployment/verification documentation. Verified lint, Vitest (`83` tests), production build, and public Playwright smoke; hosted Supabase callback/SMTP validation remains tracked in issue #17. |
+| **TOTAL** | **~3.75 hours** | | |
 
 ## Tracking Rules
 

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -13,6 +13,8 @@ import BuyerProfile from './pages/attendee/BuyerProfile';
 
 import UnifiedLogin from './pages/shared/Login';
 import UnifiedSignup from './pages/shared/Signup';
+import ForgotPassword from './pages/shared/ForgotPassword';
+import ResetPassword from './pages/shared/ResetPassword';
 
 import VendorDashboard from './pages/vendor/Dashboard';
 import VendorProducts from './pages/vendor/Products';
@@ -49,6 +51,8 @@ function App() {
                 {/* Unified Auth */}
                 <Route path="/login" element={<UnifiedLogin />} />
                 <Route path="/signup" element={<UnifiedSignup />} />
+                <Route path="/forgot-password" element={<ForgotPassword />} />
+                <Route path="/reset-password" element={<ResetPassword />} />
                 {/* Legacy redirects keep old links from breaking */}
                 <Route path="/order/login" element={<UnifiedLogin />} />
                 <Route path="/vendor/login" element={<UnifiedLogin />} />

--- a/app/src/lib/context/AuthContext.jsx
+++ b/app/src/lib/context/AuthContext.jsx
@@ -3,11 +3,17 @@ import { AuthService } from '../services/auth.service';
 import { supabase, isSupabaseConfigured } from '../supabase';
 
 const AuthContext = createContext({});
+const PASSWORD_RECOVERY_SESSION_KEY = 'skiip-password-recovery-session';
+
+function getStoredRecoverySession() {
+    return typeof window !== 'undefined' && window.sessionStorage.getItem(PASSWORD_RECOVERY_SESSION_KEY) === 'active';
+}
 
 export const AuthProvider = ({ children }) => {
     const [user, setUser] = useState(null);
     const [profile, setProfile] = useState(null);
     const [loading, setLoading] = useState(true);
+    const [passwordRecoverySession, setPasswordRecoverySession] = useState(getStoredRecoverySession);
 
     useEffect(() => {
         if (!isSupabaseConfigured()) {
@@ -43,6 +49,14 @@ export const AuthProvider = ({ children }) => {
             try {
                 const currentUser = session?.user ?? null;
                 setUser(currentUser);
+
+                if (event === 'PASSWORD_RECOVERY' && currentUser) {
+                    window.sessionStorage.setItem(PASSWORD_RECOVERY_SESSION_KEY, 'active');
+                    setPasswordRecoverySession(true);
+                } else if (!currentUser || event === 'SIGNED_OUT') {
+                    window.sessionStorage.removeItem(PASSWORD_RECOVERY_SESSION_KEY);
+                    setPasswordRecoverySession(false);
+                }
                 
                 if (currentUser) {
                     const { data, error } = await supabase
@@ -85,10 +99,17 @@ export const AuthProvider = ({ children }) => {
         };
     }, []);
 
+    function clearPasswordRecoverySession() {
+        window.sessionStorage.removeItem(PASSWORD_RECOVERY_SESSION_KEY);
+        setPasswordRecoverySession(false);
+    }
+
     const value = {
         user,
         profile,
         loading,
+        passwordRecoverySession,
+        clearPasswordRecoverySession,
         signIn: AuthService.signIn.bind(AuthService),
         signUp: AuthService.signUp.bind(AuthService),
         signOut: AuthService.signOut.bind(AuthService),

--- a/app/src/lib/services/auth.service.js
+++ b/app/src/lib/services/auth.service.js
@@ -1,5 +1,11 @@
 import { supabase } from '../supabase';
 
+function getPasswordResetRedirectUrl() {
+    const appRoot = new URL(import.meta.env.BASE_URL || '/', window.location.origin);
+    appRoot.hash = '/reset-password';
+    return appRoot.toString();
+}
+
 export const AuthService = {
     /**
      * Sign up a new user
@@ -45,6 +51,34 @@ export const AuthService = {
             email,
             password,
         });
+
+        if (error) throw error;
+        return data;
+    },
+
+    /**
+     * Email a recovery link that returns users to the password update screen.
+     * @param {string} email
+     */
+    async requestPasswordReset(email) {
+        if (!supabase) throw new Error('Supabase not configured');
+
+        const { data, error } = await supabase.auth.resetPasswordForEmail(email, {
+            redirectTo: getPasswordResetRedirectUrl(),
+        });
+
+        if (error) throw error;
+        return data;
+    },
+
+    /**
+     * Change the current authenticated user's password.
+     * @param {string} password
+     */
+    async updatePassword(password) {
+        if (!supabase) throw new Error('Supabase not configured');
+
+        const { data, error } = await supabase.auth.updateUser({ password });
 
         if (error) throw error;
         return data;

--- a/app/src/lib/services/auth.service.test.js
+++ b/app/src/lib/services/auth.service.test.js
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthService } from './auth.service';
+import { supabase } from '../supabase';
+
+vi.mock('../supabase', () => ({
+    supabase: {
+        auth: {
+            resetPasswordForEmail: vi.fn(),
+            updateUser: vi.fn(),
+        },
+    },
+}));
+
+describe('AuthService password recovery', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('requests a password reset back to the hash-routed update screen', async () => {
+        supabase.auth.resetPasswordForEmail.mockResolvedValue({ data: {}, error: null });
+
+        await AuthService.requestPasswordReset('buyer@example.com');
+
+        expect(supabase.auth.resetPasswordForEmail).toHaveBeenCalledWith('buyer@example.com', {
+            redirectTo: `${window.location.origin}/#/reset-password`,
+        });
+    });
+
+    it('updates the password through the authenticated recovery session', async () => {
+        supabase.auth.updateUser.mockResolvedValue({ data: { user: { id: 'buyer' } }, error: null });
+
+        await AuthService.updatePassword('new-password');
+
+        expect(supabase.auth.updateUser).toHaveBeenCalledWith({ password: 'new-password' });
+    });
+});

--- a/app/src/pages/shared/ForgotPassword.jsx
+++ b/app/src/pages/shared/ForgotPassword.jsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AuthService } from '../../lib/services/auth.service';
+import { useToast } from '../../components/ui/Toast';
+import SkiipLogo from '../../components/ui/SkiipLogo';
+
+export default function ForgotPassword() {
+    const { addToast } = useToast();
+    const [email, setEmail] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [submitted, setSubmitted] = useState(false);
+
+    async function handleSubmit(event) {
+        event.preventDefault();
+        setLoading(true);
+
+        try {
+            await AuthService.requestPasswordReset(email.trim());
+            setSubmitted(true);
+        } catch {
+            addToast('Could not send a password reset email. Please try again later.', 'error');
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <main className="app-page" style={{ display: 'grid', placeItems: 'center', padding: '32px 16px' }}>
+            <div style={{ maxWidth: '430px', width: '100%' }}>
+                <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '28px' }}>
+                    <SkiipLogo />
+                </div>
+
+                <div className="card" style={{ padding: '32px' }}>
+                    <h1 style={{ fontSize: '30px', fontWeight: 950, marginBottom: '8px', color: 'var(--ink)' }}>
+                        Reset Password
+                    </h1>
+
+                    {submitted ? (
+                        <>
+                            <p className="text-muted" style={{ marginBottom: '30px' }}>
+                                If an account exists for that email address, a password reset link is on its way.
+                            </p>
+                            <Link to="/login" className="btn btn-primary" style={{ width: '100%' }}>
+                                Back to Sign In
+                            </Link>
+                        </>
+                    ) : (
+                        <>
+                            <p className="text-muted" style={{ marginBottom: '30px' }}>
+                                Enter your email address and we will send a secure reset link.
+                            </p>
+
+                            <form onSubmit={handleSubmit} style={{ display: 'grid', gap: '20px' }}>
+                                <div>
+                                    <label htmlFor="recovery-email">Email Address</label>
+                                    <input
+                                        id="recovery-email"
+                                        type="email"
+                                        autoComplete="email"
+                                        value={email}
+                                        onChange={(event) => setEmail(event.target.value)}
+                                        placeholder="you@example.com"
+                                        required
+                                    />
+                                </div>
+
+                                <button type="submit" className="btn btn-primary" style={{ width: '100%' }} disabled={loading}>
+                                    {loading ? 'Sending reset link...' : 'Send Reset Link'}
+                                </button>
+
+                                <p className="text-center text-muted" style={{ fontSize: '14px' }}>
+                                    Remembered your password? <Link to="/login" className="text-accent">Sign in</Link>
+                                </p>
+                            </form>
+                        </>
+                    )}
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/app/src/pages/shared/Login.jsx
+++ b/app/src/pages/shared/Login.jsx
@@ -85,7 +85,12 @@ export default function UnifiedLogin() {
                         </div>
 
                         <div>
-                            <label htmlFor="login-password">Password</label>
+                            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                                <label htmlFor="login-password">Password</label>
+                                <Link to="/forgot-password" className="text-accent" style={{ fontSize: '14px' }}>
+                                    Forgot password?
+                                </Link>
+                            </div>
                             <div style={{ position: 'relative' }}>
                                 <input
                                     id="login-password"

--- a/app/src/pages/shared/ResetPassword.jsx
+++ b/app/src/pages/shared/ResetPassword.jsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { AuthService } from '../../lib/services/auth.service';
+import { useAuth } from '../../lib/context/AuthContext';
+import { useToast } from '../../components/ui/Toast';
+import SkiipLogo from '../../components/ui/SkiipLogo';
+
+const MIN_PASSWORD_LENGTH = 6;
+
+export default function ResetPassword() {
+    const navigate = useNavigate();
+    const { addToast } = useToast();
+    const { passwordRecoverySession, clearPasswordRecoverySession } = useAuth();
+    const [checkingSession, setCheckingSession] = useState(true);
+    const [hasSession, setHasSession] = useState(false);
+    const [password, setPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        let mounted = true;
+
+        if (!passwordRecoverySession) {
+            setHasSession(false);
+            setCheckingSession(false);
+            return () => {
+                mounted = false;
+            };
+        }
+
+        AuthService.getSession()
+            .then((session) => {
+                if (mounted) setHasSession(Boolean(session));
+            })
+            .catch(() => {
+                if (mounted) setHasSession(false);
+            })
+            .finally(() => {
+                if (mounted) setCheckingSession(false);
+            });
+
+        return () => {
+            mounted = false;
+        };
+    }, [passwordRecoverySession]);
+
+    async function handleSubmit(event) {
+        event.preventDefault();
+
+        if (password !== confirmPassword) {
+            addToast('Passwords do not match.', 'error');
+            return;
+        }
+
+        setLoading(true);
+        try {
+            await AuthService.updatePassword(password);
+            clearPasswordRecoverySession();
+            try {
+                await AuthService.signOut();
+            } catch {
+                // Password update has succeeded; do not turn a sign-out issue into a reset failure.
+            }
+            addToast('Password updated. Sign in with your new password.', 'success');
+            navigate('/login', { replace: true });
+        } catch (error) {
+            addToast(error.message || 'Could not update your password. Please request a new reset link.', 'error');
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <main className="app-page" style={{ display: 'grid', placeItems: 'center', padding: '32px 16px' }}>
+            <div style={{ maxWidth: '430px', width: '100%' }}>
+                <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '28px' }}>
+                    <SkiipLogo />
+                </div>
+
+                <div className="card" style={{ padding: '32px' }}>
+                    <h1 style={{ fontSize: '30px', fontWeight: 950, marginBottom: '8px', color: 'var(--ink)' }}>
+                        Choose New Password
+                    </h1>
+
+                    {checkingSession && <p className="text-muted">Checking your reset link...</p>}
+
+                    {!checkingSession && !hasSession && (
+                        <>
+                            <p className="text-muted" style={{ marginBottom: '30px' }}>
+                                This reset link is invalid or has expired. Request a new link to continue.
+                            </p>
+                            <Link to="/forgot-password" className="btn btn-primary" style={{ width: '100%' }}>
+                                Request New Link
+                            </Link>
+                        </>
+                    )}
+
+                    {!checkingSession && hasSession && (
+                        <>
+                            <p className="text-muted" style={{ marginBottom: '30px' }}>
+                                Enter a new password for your account.
+                            </p>
+
+                            <form onSubmit={handleSubmit} style={{ display: 'grid', gap: '20px' }}>
+                                <div>
+                                    <label htmlFor="new-password">New Password</label>
+                                    <input
+                                        id="new-password"
+                                        type="password"
+                                        autoComplete="new-password"
+                                        value={password}
+                                        onChange={(event) => setPassword(event.target.value)}
+                                        minLength={MIN_PASSWORD_LENGTH}
+                                        required
+                                    />
+                                </div>
+
+                                <div>
+                                    <label htmlFor="confirm-password">Confirm Password</label>
+                                    <input
+                                        id="confirm-password"
+                                        type="password"
+                                        autoComplete="new-password"
+                                        value={confirmPassword}
+                                        onChange={(event) => setConfirmPassword(event.target.value)}
+                                        minLength={MIN_PASSWORD_LENGTH}
+                                        required
+                                    />
+                                </div>
+
+                                <p className="text-muted" style={{ fontSize: '13px' }}>
+                                    Password must be at least {MIN_PASSWORD_LENGTH} characters.
+                                </p>
+
+                                <button type="submit" className="btn btn-primary" style={{ width: '100%' }} disabled={loading}>
+                                    {loading ? 'Updating password...' : 'Update Password'}
+                                </button>
+                            </form>
+                        </>
+                    )}
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/app/src/pages/shared/ResetPassword.test.jsx
+++ b/app/src/pages/shared/ResetPassword.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ResetPassword from './ResetPassword';
+import { AuthService } from '../../lib/services/auth.service';
+import { useAuth } from '../../lib/context/AuthContext';
+
+vi.mock('../../lib/context/AuthContext', () => ({
+    useAuth: vi.fn(),
+}));
+
+vi.mock('../../lib/services/auth.service', () => ({
+    AuthService: {
+        getSession: vi.fn(),
+        updatePassword: vi.fn(),
+        signOut: vi.fn(),
+    },
+}));
+
+function renderResetPassword() {
+    render(
+        <MemoryRouter>
+            <ResetPassword />
+        </MemoryRouter>
+    );
+}
+
+describe('ResetPassword', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not offer password updates for a normal authenticated visit', async () => {
+        useAuth.mockReturnValue({
+            passwordRecoverySession: false,
+            clearPasswordRecoverySession: vi.fn(),
+        });
+
+        renderResetPassword();
+
+        expect(await screen.findByText(/reset link is invalid or has expired/i)).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /update password/i })).not.toBeInTheDocument();
+        expect(AuthService.getSession).not.toHaveBeenCalled();
+    });
+
+    it('updates a password only after a recovery event has opened a session', async () => {
+        const clearPasswordRecoverySession = vi.fn();
+        useAuth.mockReturnValue({
+            passwordRecoverySession: true,
+            clearPasswordRecoverySession,
+        });
+        AuthService.getSession.mockResolvedValue({ user: { id: 'buyer-user' } });
+        AuthService.updatePassword.mockResolvedValue({});
+        AuthService.signOut.mockResolvedValue();
+
+        renderResetPassword();
+
+        fireEvent.change(await screen.findByLabelText('New Password'), { target: { value: 'changed-password' } });
+        fireEvent.change(screen.getByLabelText('Confirm Password'), { target: { value: 'changed-password' } });
+        fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+
+        await waitFor(() => expect(AuthService.updatePassword).toHaveBeenCalledWith('changed-password'));
+        expect(clearPasswordRecoverySession).toHaveBeenCalled();
+        expect(AuthService.signOut).toHaveBeenCalled();
+    });
+});

--- a/app/tests/e2e/smoke.spec.js
+++ b/app/tests/e2e/smoke.spec.js
@@ -152,6 +152,21 @@ test.describe('public smoke', () => {
     ).toBeVisible();
   });
 
+  test('sign-in links to the password recovery request page', async ({ page }) => {
+    await page.goto(appPath('/login'));
+    await page.getByRole('link', { name: /forgot password/i }).click();
+    await expect(page).toHaveURL(/#\/forgot-password$/);
+    await expect(page.getByRole('heading', { name: /reset password/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /send reset link/i })).toBeVisible();
+  });
+
+  test('password update form requires a recovery session', async ({ page }) => {
+    await page.goto(appPath('/reset-password'));
+    await expect(page.getByRole('heading', { name: /choose new password/i })).toBeVisible();
+    await expect(page.getByText(/reset link is invalid or has expired/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /update password/i })).toHaveCount(0);
+  });
+
   test('protected routes redirect unauthenticated users to login', async ({ page }) => {
     for (const protectedPath of ['/vendor/dashboard', '/admin/orders', '/admin/events', '/admin/settings']) {
       await page.goto(appPath(protectedPath));

--- a/docs/architecture/auth-model.md
+++ b/docs/architecture/auth-model.md
@@ -13,6 +13,7 @@ Current roles:
 Current account-entry paths:
 
 - buyer self-signup through `/signup`
+- password recovery for existing accounts through `/#/forgot-password` and `/#/reset-password`, backed by Supabase Auth PKCE recovery links
 - admin-created seller/store setup through the admin vendor management UI
 - no public or invite-code vendor self-signup for the May 2026 launch
 

--- a/docs/launch/DEPLOYMENT.md
+++ b/docs/launch/DEPLOYMENT.md
@@ -11,6 +11,7 @@ This is the stable entrypoint for deployment documentation. The detailed topics 
 - [Supabase Function Secrets](./deployment/supabase-function-secrets.md)
 - [Allowed Origins](./deployment/allowed-origins.md)
 - [Pilot Auth Decision](./deployment/pilot-auth-decision.md)
+- [Password Recovery](./deployment/password-recovery.md)
 - [Migrations and Schema Truth](./deployment/migrations-and-schema-truth.md)
 - [Edge Functions](./deployment/edge-functions.md)
 - [Stripe Configuration](./deployment/stripe-configuration.md)

--- a/docs/launch/ENVIRONMENT_MATRIX.md
+++ b/docs/launch/ENVIRONMENT_MATRIX.md
@@ -49,6 +49,7 @@ This is the May 2026 launch source of truth for environment parity. Do not commi
 | Admin payment switch | Admin Settings `Checkout availability` writes `app_settings.payment_controls`; checkout is enabled only when this and `PAYMENTS_ENABLED` are both on. | Same; use this first for curfew/operator stop-sale after the live window opens. |
 | WhatsApp status callback | Callback points to `/functions/v1/whatsapp-status-webhook`; token query matches `TWILIO_WEBHOOK_TOKEN` if configured. | Same with production Supabase URL. |
 | Resend webhook | Callback points to `/functions/v1/resend-email-webhook` if provider webhooks are enabled. | Same with production Supabase URL. |
+| Supabase Auth password recovery | Auth redirect allow-list includes the staging app `/#/reset-password` callback; send and redeem one reset email. | Auth redirect allow-list includes `https://www.skiip.co.uk/#/reset-password`; production SMTP can deliver recovery email. |
 
 ## Pre-Test Verification
 
@@ -59,8 +60,9 @@ Before May 12 staging testing:
 3. Confirm `ALLOWED_ORIGINS` includes only the staging app origin, local dev origins if needed, and any approved preview origin.
 4. Confirm Stripe dashboard webhook endpoint and secret match the deployed staging function.
 5. Confirm notification provider sender/callback settings match staging function URLs.
-6. Run one immediate order and one scheduled order through Stripe test checkout.
-7. Confirm webhook marks payment succeeded, inventory finalizes, notifications queue, and vendor/admin views show the order.
+6. Confirm Supabase Auth password recovery callback and email delivery with one test account.
+7. Run one immediate order and one scheduled order through Stripe test checkout.
+8. Confirm webhook marks payment succeeded, inventory finalizes, notifications queue, and vendor/admin views show the order.
 
 Before production launch:
 
@@ -69,3 +71,4 @@ Before production launch:
 3. Do not switch Stripe keys without also checking webhook endpoints and connected-account mode.
 4. Confirm Web Analytics and Speed Insights are enabled on the production Vercel project.
 5. Confirm Search Console ownership, sitemap submission, and root URL inspection for the production domain.
+6. Confirm the production Supabase Auth callback URL and SMTP sender deliver a usable password recovery email.

--- a/docs/launch/deployment/password-recovery.md
+++ b/docs/launch/deployment/password-recovery.md
@@ -1,0 +1,34 @@
+# Password Recovery
+
+Read this when deploying or testing account password reset for the product app.
+
+## Implemented Flow
+
+- The unified sign-in page links to `/#/forgot-password`.
+- The request form calls Supabase Auth `resetPasswordForEmail()` with a return URL for `/#/reset-password`.
+- The product app uses Supabase PKCE auth and `HashRouter`; the emailed callback exchanges the PKCE code and then exposes the password form only after Supabase emits the password-recovery session event.
+- The password form calls `updateUser({ password })`, signs out the recovery session, and returns the user to sign-in.
+- The request confirmation does not disclose whether an email address exists.
+
+No schema migration or edge function deployment is required for this flow.
+
+## Hosted Supabase Setup
+
+This is external configuration and must be completed separately for each Supabase environment:
+
+1. In Auth URL Configuration, allow the deployed product-app password callback URL.
+   - Production: `https://www.skiip.co.uk/#/reset-password`
+   - Staging: use the matching staged product-app origin with `/#/reset-password`
+2. Confirm the Site URL points to the correct product-app origin for the environment.
+3. Configure a production SMTP provider for Supabase Auth recovery emails. Supabase's default mail sender is intended only for testing and is rate limited.
+
+For local Supabase testing, add the local Vite callback origin, such as `http://127.0.0.1:5173/#/reset-password`, to the local Auth redirect allow-list before testing email links.
+
+## Verification
+
+1. Open `/#/login` and choose `Forgot password?`.
+2. Request a link for a test buyer account and confirm the response remains generic.
+3. Open the delivered email link in the same browser used to request it, because the PKCE verifier is stored in that browser.
+4. Set a new password on `/#/reset-password`.
+5. Confirm the recovery session signs out and that the account can sign in with the new password.
+6. Repeat against staging before enabling the production callback and mail configuration.

--- a/docs/launch/deployment/post-deploy-verification.md
+++ b/docs/launch/deployment/post-deploy-verification.md
@@ -24,3 +24,4 @@ After any meaningful backend or frontend deploy:
 18. confirm Search Console sitemap/indexing checks after production deploys that affect search metadata
 19. if external database-health monitoring is configured, confirm the Supabase Metrics API scrape target is healthy
 20. if self-serve signup is in scope for the environment, verify actual signup behavior matches the chosen confirmation policy
+21. request and redeem a password recovery email using a test account, then sign in with the new password

--- a/docs/reference/BACKEND_BOUNDARY_AUDIT.md
+++ b/docs/reference/BACKEND_BOUNDARY_AUDIT.md
@@ -21,7 +21,7 @@ The current launch boundary is broadly server-authoritative for sensitive busine
 
 The active browser-side writes that remain are:
 
-- Supabase Auth signup, sign-in, and sign-out calls
+- Supabase Auth signup, sign-in, sign-out, and password recovery calls
 - seller product create/update/soft-delete writes to `products`
 - seller product image uploads to Supabase Storage
 
@@ -35,6 +35,7 @@ No new untracked high-risk browser-side privileged write was found in this audit
 | --- | --- | --- | --- |
 | `AuthService.signUp()` in [`auth.service.js`](../../app/src/lib/services/auth.service.js) and routed buyer signup in [`Signup.jsx`](../../app/src/pages/shared/Signup.jsx) | Supabase Auth creates the user; `handle_new_user()` creates/reconciles `user_profiles` | Safe as-is for closed pilot | Browser does not choose privileged roles. New profiles are forced to buyer by backend trigger behavior documented in the architecture and RLS matrix. |
 | `AuthService.signIn()` / `AuthService.signOut()` | Supabase Auth session lifecycle | Safe as-is for closed pilot | Session mutations are Supabase Auth-managed, not application data privilege writes. |
+| `AuthService.requestPasswordReset()` / `AuthService.updatePassword()` in [`auth.service.js`](../../app/src/lib/services/auth.service.js), routed through [`ForgotPassword.jsx`](../../app/src/pages/shared/ForgotPassword.jsx) and [`ResetPassword.jsx`](../../app/src/pages/shared/ResetPassword.jsx) | Supabase Auth recovery email and password update lifecycle | Safe as-is for closed pilot | Reset requests return a generic confirmation; the update form is exposed only after Supabase emits `PASSWORD_RECOVERY` for the PKCE email callback, and the recovery state is cleared after use. |
 | `ProductService.createProduct()` | Direct `products.insert()` from browser | Safe as-is for closed pilot | Seller insert policy checks that `store_id` belongs to the authenticated user's non-deleted store. Admin policy can manage all products. |
 | `ProductService.updateProduct()` | Direct `products.update()` from browser | Safe as-is for closed pilot | Seller update policy uses and checks ownership through `stores.user_id = auth.uid()`. This covers product edits and soft-delete updates. |
 | `ProductService.deleteProduct()` | Direct `products.update({ deleted_at, status: 'archived' })` from browser | Safe as-is for closed pilot | Soft-delete is constrained by the same seller-owned product update policy. |
@@ -117,7 +118,7 @@ This audit was built by searching `app/src` for:
 - Edge Function calls: `functions.invoke(`
 - RPC calls: `.rpc(`
 - storage writes: `.upload(` and `.remove(`
-- auth mutations: `signUp`, `signInWithPassword`, `signOut`
+- auth mutations: `signUp`, `signInWithPassword`, `signOut`, `resetPasswordForEmail`, `updateUser`, and `PASSWORD_RECOVERY`
 - realtime subscriptions: `.channel(` and `postgres_changes`
 
 Findings were cross-checked against:
@@ -127,4 +128,4 @@ Findings were cross-checked against:
 - [`supabase/config.toml`](../../supabase/config.toml)
 - authoritative migrations in [`supabase/migrations`](../../supabase/migrations)
 
-No runtime behavior was changed as part of this audit.
+No runtime behavior was changed as part of the original audit. The browser-write inventory was later amended to include the password-recovery hotfix.


### PR DESCRIPTION
## Summary
- Add `Forgot password?` from the unified login flow with `/#/forgot-password` and `/#/reset-password` screens.
- Integrate Supabase Auth PKCE recovery via `resetPasswordForEmail()` and `updateUser()`.
- Gate the password-update form on Supabase's `PASSWORD_RECOVERY` event and clear recovery state after a successful reset.
- Add unit/browser smoke coverage and update active auth, deployment, environment-matrix, backend-boundary, and Phase 6 documentation.

## Why
Existing users had no self-service way to recover an account password. This is a contained launch-critical auth gap: it uses Supabase Auth directly and does not require schema or edge-function changes.

## Validation
- `npm run lint`
- `npm run test` - 16 test files, 83 tests passed
- `npm run build`
- `npm run test:e2e` - 5 public smoke checks passed; 3 credential-dependent authenticated checks skipped as configured

## Deployment Verification Still Required
- Allow the staged product-app `/#/reset-password` callback in hosted Supabase Auth and redeem a real reset email in staging.
- Allow `https://www.skiip.co.uk/#/reset-password` for production.
- Confirm production Supabase Auth SMTP/sender delivery for recovery emails.

These live-provider checks are documented in `docs/launch/deployment/password-recovery.md` and align with the existing environment-parity work in #17.