### PR TITLE
[codex] fix Supabase password recovery callback routing

### DIFF
--- a/PHASE6.md
+++ b/PHASE6.md
@@ -12,7 +12,8 @@ Historical progress logs:
 | Dean Gibson | ~0.5 hours | 2026/05/24 | Phase 6 tracking rollover. Capped the Phase 5 progress log, moved Phase 1-5 progress history into `docs/`, and created `PHASE6.md` as the active root tracker for new work. |
 | Dean Gibson | ~2.5 hours | 2026/05/25 | Admin portal operational restructure hotfix. Split admin overview, orders, vendor performance, event setup, and checkout settings into focused routed surfaces; added action-path test coverage and updated active operations/launch documentation. Added local lint, Vitest, build, route-protection smoke, and visual-layout evidence; authenticated operational action verification remains a draft-PR merge gate. |
 | Dean Gibson | ~0.75 hours | 2026/05/25 | Added Supabase PKCE password recovery for existing accounts: reset-request and password-update screens, recovery-event guard, unified login link, hash-routed callback support, focused tests, and deployment/verification documentation. Verified lint, Vitest (`83` tests), production build, and public Playwright smoke; hosted Supabase callback/SMTP validation remains tracked in issue #17. |
-| **TOTAL** | **~3.75 hours** | | |
+| Dean Gibson | ~0.5 hours | 2026/05/26 | Follow-up password recovery callback hotfix after live validation exposed an `otp_expired` callback being interpreted as a hash-router 404. Added callback error normalization and recovery-event routing, corrected the production callback origin/documented Supabase email-template requirement, and verified lint, Vitest (`86` tests), production build, and public Playwright smoke including the failed-link regression. |
+| **TOTAL** | **~4.25 hours** | | |
 
 ## Tracking Rules
 

--- a/app/src/lib/auth-callback.js
+++ b/app/src/lib/auth-callback.js
@@ -1,0 +1,36 @@
+const AUTH_ERROR_KEYS = ['error', 'error_code', 'error_description'];
+
+function readCallbackValue(url, key) {
+    const queryValue = url.searchParams.get(key);
+    if (queryValue) return queryValue;
+
+    if (!url.hash || url.hash.startsWith('#/')) return null;
+
+    return new URLSearchParams(url.hash.slice(1)).get(key);
+}
+
+export function getPasswordRecoveryErrorRoute(href) {
+    const url = new URL(href);
+
+    if (readCallbackValue(url, 'error_code') !== 'otp_expired') {
+        return null;
+    }
+
+    AUTH_ERROR_KEYS.forEach((key) => url.searchParams.delete(key));
+    url.hash = '/reset-password?reason=expired';
+    return url.toString();
+}
+
+export function routePasswordRecoveryErrorCallback() {
+    const resetRoute = getPasswordRecoveryErrorRoute(window.location.href);
+    if (!resetRoute) return false;
+
+    window.history.replaceState(window.history.state, '', resetRoute);
+    return true;
+}
+
+export function routeActivePasswordRecoverySession() {
+    if (window.location.hash.startsWith('#/reset-password')) return;
+
+    window.location.hash = '/reset-password';
+}

--- a/app/src/lib/auth-callback.test.js
+++ b/app/src/lib/auth-callback.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { getPasswordRecoveryErrorRoute, routeActivePasswordRecoverySession } from './auth-callback';
+
+describe('password recovery callback routing', () => {
+    it('moves expired Supabase callbacks out of the hash-router 404 path', () => {
+        const callbackUrl =
+            'https://skiip.vercel.app/?error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired&sb=';
+
+        expect(getPasswordRecoveryErrorRoute(callbackUrl)).toBe(
+            'https://skiip.vercel.app/#/reset-password?reason=expired'
+        );
+    });
+
+    it('ignores ordinary application routes', () => {
+        expect(getPasswordRecoveryErrorRoute('https://skiip.vercel.app/#/login')).toBeNull();
+    });
+
+    it('opens the password form after Supabase establishes a recovery session', () => {
+        window.history.replaceState(null, '', '/');
+
+        routeActivePasswordRecoverySession();
+
+        expect(window.location.hash).toBe('#/reset-password');
+    });
+});

--- a/app/src/lib/context/AuthContext.jsx
+++ b/app/src/lib/context/AuthContext.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { AuthService } from '../services/auth.service';
+import { routeActivePasswordRecoverySession } from '../auth-callback';
 import { supabase, isSupabaseConfigured } from '../supabase';
 
 const AuthContext = createContext({});
@@ -53,6 +54,7 @@ export const AuthProvider = ({ children }) => {
                 if (event === 'PASSWORD_RECOVERY' && currentUser) {
                     window.sessionStorage.setItem(PASSWORD_RECOVERY_SESSION_KEY, 'active');
                     setPasswordRecoverySession(true);
+                    routeActivePasswordRecoverySession();
                 } else if (!currentUser || event === 'SIGNED_OUT') {
                     window.sessionStorage.removeItem(PASSWORD_RECOVERY_SESSION_KEY);
                     setPasswordRecoverySession(false);

--- a/app/src/main.jsx
+++ b/app/src/main.jsx
@@ -5,9 +5,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import App from './App';
 import { AuthProvider } from './lib/context/AuthContext';
+import { routePasswordRecoveryErrorCallback } from './lib/auth-callback';
 import ErrorBoundary from './components/shared/ErrorBoundary';
 import * as Sentry from "@sentry/react";
 import './index.css';
+
+routePasswordRecoveryErrorCallback();
 
 if (import.meta.env.VITE_SENTRY_DSN) {
   Sentry.init({

--- a/app/tests/e2e/smoke.spec.js
+++ b/app/tests/e2e/smoke.spec.js
@@ -167,6 +167,13 @@ test.describe('public smoke', () => {
     await expect(page.getByRole('button', { name: /update password/i })).toHaveCount(0);
   });
 
+  test('expired Supabase recovery callbacks show the reset-link recovery state', async ({ page }) => {
+    await page.goto('/?error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired&sb=');
+    await expect(page).toHaveURL(/#\/reset-password\?reason=expired$/);
+    await expect(page.getByText(/reset link is invalid or has expired/i)).toBeVisible();
+    await expect(page.getByRole('link', { name: /request new link/i })).toBeVisible();
+  });
+
   test('protected routes redirect unauthenticated users to login', async ({ page }) => {
     for (const protectedPath of ['/vendor/dashboard', '/admin/orders', '/admin/events', '/admin/settings']) {
       await page.goto(appPath(protectedPath));

--- a/docs/launch/ENVIRONMENT_MATRIX.md
+++ b/docs/launch/ENVIRONMENT_MATRIX.md
@@ -49,7 +49,7 @@ This is the May 2026 launch source of truth for environment parity. Do not commi
 | Admin payment switch | Admin Settings `Checkout availability` writes `app_settings.payment_controls`; checkout is enabled only when this and `PAYMENTS_ENABLED` are both on. | Same; use this first for curfew/operator stop-sale after the live window opens. |
 | WhatsApp status callback | Callback points to `/functions/v1/whatsapp-status-webhook`; token query matches `TWILIO_WEBHOOK_TOKEN` if configured. | Same with production Supabase URL. |
 | Resend webhook | Callback points to `/functions/v1/resend-email-webhook` if provider webhooks are enabled. | Same with production Supabase URL. |
-| Supabase Auth password recovery | Auth redirect allow-list includes the staging app `/#/reset-password` callback; send and redeem one reset email. | Auth redirect allow-list includes `https://www.skiip.co.uk/#/reset-password`; production SMTP can deliver recovery email. |
+| Supabase Auth password recovery | Auth redirect allow-list includes the staging app `/#/reset-password` callback; send and redeem one reset email. | Auth redirect allow-list includes `https://skiip.vercel.app/#/reset-password` and any active custom product-app auth origin; production SMTP can deliver recovery email. |
 
 ## Pre-Test Verification
 

--- a/docs/launch/deployment/password-recovery.md
+++ b/docs/launch/deployment/password-recovery.md
@@ -7,6 +7,7 @@ Read this when deploying or testing account password reset for the product app.
 - The unified sign-in page links to `/#/forgot-password`.
 - The request form calls Supabase Auth `resetPasswordForEmail()` with a return URL for `/#/reset-password`.
 - The product app uses Supabase PKCE auth and `HashRouter`; the emailed callback exchanges the PKCE code and then exposes the password form only after Supabase emits the password-recovery session event.
+- If Supabase returns an expired/invalid OTP failure in URL fragments, the app normalizes the callback into `/#/reset-password?reason=expired` rather than rendering a hash-router 404.
 - The password form calls `updateUser({ password })`, signs out the recovery session, and returns the user to sign-in.
 - The request confirmation does not disclose whether an email address exists.
 
@@ -17,12 +18,14 @@ No schema migration or edge function deployment is required for this flow.
 This is external configuration and must be completed separately for each Supabase environment:
 
 1. In Auth URL Configuration, allow the deployed product-app password callback URL.
-   - Production: `https://www.skiip.co.uk/#/reset-password`
+   - Verified current production app origin: `https://skiip.vercel.app/#/reset-password`
+   - Add `https://www.skiip.co.uk/#/reset-password` only if that custom domain serves the product app's authentication screens.
    - Staging: use the matching staged product-app origin with `/#/reset-password`
 2. Confirm the Site URL points to the correct product-app origin for the environment.
 3. Configure a production SMTP provider for Supabase Auth recovery emails. Supabase's default mail sender is intended only for testing and is rate limited.
+4. If the hosted recovery email template was customized, ensure the action link uses `{{ .RedirectTo }}` rather than always returning users to `{{ .SiteURL }}`.
 
-For local Supabase testing, add the local Vite callback origin, such as `http://127.0.0.1:5173/#/reset-password`, to the local Auth redirect allow-list before testing email links.
+The reset request uses the browser's current product-app origin, so every approved origin from which password reset can be requested must have its matching `/#/reset-password` callback allowed in Supabase. For local testing, add a callback such as `http://127.0.0.1:5173/#/reset-password`. For approved Vercel previews, add the exact preview callback or a narrowly scoped preview wildcard as described in the Supabase redirect URL guide.
 
 ## Verification
 
@@ -31,4 +34,5 @@ For local Supabase testing, add the local Vite callback origin, such as `http://
 3. Open the delivered email link in the same browser used to request it, because the PKCE verifier is stored in that browser.
 4. Set a new password on `/#/reset-password`.
 5. Confirm the recovery session signs out and that the account can sign in with the new password.
-6. Repeat against staging before enabling the production callback and mail configuration.
+6. Request a new email if Supabase reports `otp_expired`; recovery links are single-use and can be consumed by an earlier click or email security-link scanner.
+7. Repeat against staging before enabling the production callback and mail configuration.


### PR DESCRIPTION
## Summary
- Route Supabase `otp_expired` password recovery callbacks into the reset-password screen instead of the hash-router 404.
- Route successful `PASSWORD_RECOVERY` sessions into the password form when hosted configuration returns the user to the app root.
- Correct the documented production callback origin to `https://skiip.vercel.app` and document the Supabase `{{ .RedirectTo }}` recovery-template requirement.
- Add unit and Playwright coverage for the exact live callback URL reported after #77 merged.

## Root Cause
The product app uses `HashRouter`, while Supabase returns failed recovery-link details in the URL fragment (`#error=...`). The app interpreted that fragment as a client route and rendered its 404 page. The live callback origin must also match the product app origin actually serving auth screens.

## Validation
- `npm run lint`
- `npm run test` - 17 test files, 86 tests passed
- `npm run build`
- `npm run test:e2e` - 6 public smoke checks passed, including the reported expired-link callback URL; 3 credential-dependent authenticated checks skipped as configured

## After Merge
- In Supabase Auth URL Configuration, confirm `https://skiip.vercel.app/#/reset-password` is allowed.
- If the recovery email template is customized, confirm it uses `{{ .RedirectTo }}`.
- Request a fresh reset email; the previously reported `otp_expired` link cannot be reused.