### PR TITLE
Fail closed on Stripe mode/key mismatches

### DIFF
--- a/docs/launch/deployment/stripe-configuration.md
+++ b/docs/launch/deployment/stripe-configuration.md
@@ -35,7 +35,7 @@ Important:
 
 - the webhook signing secret must come from the exact hosted Stripe webhook endpoint in use
 - do not mix Stripe CLI listener secrets with hosted endpoint secrets
-- set `STRIPE_MODE=test` for test-mode endpoints and `STRIPE_MODE=live` for live endpoints; Stripe clients reject mismatched `sk_`/`rk_` key prefixes at startup and mismatched `event.livemode` webhooks before event claiming
+- set `STRIPE_MODE=test` for test-mode endpoints and `STRIPE_MODE=live` for live endpoints; Stripe clients reject mismatched `sk_test_`, `rk_test_`, `sk_live_`, and `rk_live_` key prefixes at startup and mismatched `event.livemode` webhooks before event claiming
 - set `PAYMENTS_ENABLED=false` to pause only new Checkout Session creation while leaving live webhooks, refunds, reconciliation, disputes, and Connect status recovery available
 - `PAYMENTS_ENABLED` is the Supabase environment master switch; Admin Settings `Checkout availability` writes `app_settings.payment_controls` and can pause/resume checkout only when the master switch is `true`
 - live webhook endpoint API version must be pinned to `2023-10-16` while the edge functions remain on `stripe@14.x`

--- a/docs/launch/deployment/stripe-configuration.md
+++ b/docs/launch/deployment/stripe-configuration.md
@@ -35,7 +35,7 @@ Important:
 
 - the webhook signing secret must come from the exact hosted Stripe webhook endpoint in use
 - do not mix Stripe CLI listener secrets with hosted endpoint secrets
-- set `STRIPE_MODE=test` for test-mode endpoints and `STRIPE_MODE=live` for live endpoints; mismatched `event.livemode` webhooks are rejected before event claiming
+- set `STRIPE_MODE=test` for test-mode endpoints and `STRIPE_MODE=live` for live endpoints; Stripe clients reject mismatched `sk_`/`rk_` key prefixes at startup and mismatched `event.livemode` webhooks before event claiming
 - set `PAYMENTS_ENABLED=false` to pause only new Checkout Session creation while leaving live webhooks, refunds, reconciliation, disputes, and Connect status recovery available
 - `PAYMENTS_ENABLED` is the Supabase environment master switch; Admin Settings `Checkout availability` writes `app_settings.payment_controls` and can pause/resume checkout only when the master switch is `true`
 - live webhook endpoint API version must be pinned to `2023-10-16` while the edge functions remain on `stripe@14.x`

--- a/supabase/functions/_shared/stripe-config.ts
+++ b/supabase/functions/_shared/stripe-config.ts
@@ -20,6 +20,18 @@ export class StripeModeMismatchError extends Error {
   }
 }
 
+export class StripeKeyModeMismatchError extends Error {
+  expectedMode: StripeMode
+  actualMode: StripeMode
+
+  constructor(expectedMode: StripeMode, actualMode: StripeMode) {
+    super(`Stripe secret key mode mismatch: expected ${expectedMode}, received ${actualMode}`)
+    this.name = 'StripeKeyModeMismatchError'
+    this.expectedMode = expectedMode
+    this.actualMode = actualMode
+  }
+}
+
 export function getRequiredStripeMode(env: EnvReader = Deno.env): StripeMode {
   const rawMode = env.get('STRIPE_MODE')?.trim().toLowerCase()
 
@@ -28,6 +40,38 @@ export function getRequiredStripeMode(env: EnvReader = Deno.env): StripeMode {
   }
 
   throw new Error('STRIPE_MODE must be set to "test" or "live"')
+}
+
+export function getStripeSecretKeyMode(secretKey: string): StripeMode | null {
+  const trimmedKey = secretKey.trim()
+
+  if (/^(sk|rk)_test_/.test(trimmedKey)) {
+    return 'test'
+  }
+
+  if (/^(sk|rk)_live_/.test(trimmedKey)) {
+    return 'live'
+  }
+
+  return null
+}
+
+export function assertStripeSecretKeyMatchesMode(
+  secretKey: string,
+  env: EnvReader = Deno.env,
+) {
+  const expectedMode = getRequiredStripeMode(env)
+  const actualMode = getStripeSecretKeyMode(secretKey)
+
+  if (!actualMode) {
+    throw new Error(
+      `STRIPE_SECRET_KEY must start with sk_${expectedMode}_ or rk_${expectedMode}_`,
+    )
+  }
+
+  if (actualMode !== expectedMode) {
+    throw new StripeKeyModeMismatchError(expectedMode, actualMode)
+  }
 }
 
 export function assertStripeLivemode(
@@ -75,8 +119,10 @@ export async function constructWithWebhookSecrets<T>(
   throw new Error(errors[0] || 'Stripe webhook signature verification failed')
 }
 
-export function createStripeClient(secretKey: string) {
-  return new Stripe(secretKey, {
+export function createStripeClient(secretKey: string, env: EnvReader = Deno.env) {
+  assertStripeSecretKeyMatchesMode(secretKey, env)
+
+  return new Stripe(secretKey.trim(), {
     apiVersion: STRIPE_API_VERSION,
     httpClient: Stripe.createFetchHttpClient(),
   })

--- a/supabase/functions/tests/stripe-config-test.ts
+++ b/supabase/functions/tests/stripe-config-test.ts
@@ -7,6 +7,7 @@ import {
   assertStripeSecretKeyMatchesMode,
   assertStripeLivemode,
   constructWithWebhookSecrets,
+  createStripeClient,
   getStripeSecretKeyMode,
   getRequiredStripeMode,
   isPaymentsEnabled,
@@ -90,6 +91,15 @@ Deno.test("assertStripeSecretKeyMatchesMode rejects non-secret Stripe keys", () 
     Error,
     "STRIPE_SECRET_KEY must start with sk_test_ or rk_test_",
   );
+});
+
+Deno.test("createStripeClient enforces STRIPE_MODE against the key prefix", () => {
+  const error = assertThrows(
+    () => createStripeClient("sk_live_123", env({ STRIPE_MODE: "test" })),
+    StripeKeyModeMismatchError,
+  );
+  assertEquals(error.expectedMode, "test");
+  assertEquals(error.actualMode, "live");
 });
 
 Deno.test("isPaymentsEnabled only accepts exact true", () => {

--- a/supabase/functions/tests/stripe-config-test.ts
+++ b/supabase/functions/tests/stripe-config-test.ts
@@ -4,11 +4,14 @@ import {
   assertRejects,
 } from "jsr:@std/assert@1";
 import {
+  assertStripeSecretKeyMatchesMode,
   assertStripeLivemode,
   constructWithWebhookSecrets,
+  getStripeSecretKeyMode,
   getRequiredStripeMode,
   isPaymentsEnabled,
   parseStripeWebhookSecrets,
+  StripeKeyModeMismatchError,
   StripeModeMismatchError,
 } from "../_shared/stripe-config.ts";
 
@@ -51,6 +54,42 @@ Deno.test("assertStripeLivemode rejects mismatched test and live events", () => 
   );
   assertEquals(liveModeError.expectedMode, "live");
   assertEquals(liveModeError.actualMode, "test");
+});
+
+Deno.test("getStripeSecretKeyMode detects live and test secret key prefixes", () => {
+  assertEquals(getStripeSecretKeyMode("sk_test_123"), "test");
+  assertEquals(getStripeSecretKeyMode("rk_test_123"), "test");
+  assertEquals(getStripeSecretKeyMode("sk_live_123"), "live");
+  assertEquals(getStripeSecretKeyMode("rk_live_123"), "live");
+  assertEquals(getStripeSecretKeyMode("pk_test_123"), null);
+  assertEquals(getStripeSecretKeyMode("not-a-stripe-key"), null);
+});
+
+Deno.test("assertStripeSecretKeyMatchesMode rejects key prefix mismatches", () => {
+  assertStripeSecretKeyMatchesMode("sk_test_123", env({ STRIPE_MODE: "test" }));
+  assertStripeSecretKeyMatchesMode("rk_live_123", env({ STRIPE_MODE: "live" }));
+
+  const testModeError = assertThrows(
+    () => assertStripeSecretKeyMatchesMode("sk_live_123", env({ STRIPE_MODE: "test" })),
+    StripeKeyModeMismatchError,
+  );
+  assertEquals(testModeError.expectedMode, "test");
+  assertEquals(testModeError.actualMode, "live");
+
+  const liveModeError = assertThrows(
+    () => assertStripeSecretKeyMatchesMode("sk_test_123", env({ STRIPE_MODE: "live" })),
+    StripeKeyModeMismatchError,
+  );
+  assertEquals(liveModeError.expectedMode, "live");
+  assertEquals(liveModeError.actualMode, "test");
+});
+
+Deno.test("assertStripeSecretKeyMatchesMode rejects non-secret Stripe keys", () => {
+  assertThrows(
+    () => assertStripeSecretKeyMatchesMode("pk_test_123", env({ STRIPE_MODE: "test" })),
+    Error,
+    "STRIPE_SECRET_KEY must start with sk_test_ or rk_test_",
+  );
 });
 
 Deno.test("isPaymentsEnabled only accepts exact true", () => {


### PR DESCRIPTION
## Summary

- add a shared Stripe secret-key mode guard for `sk_` and `rk_` prefixes
- fail closed when `STRIPE_MODE` disagrees with the configured Stripe secret key
- reuse the guard in shared Stripe client creation so checkout, refunds, Connect, reconciliation, and webhook-adjacent clients get the same boundary
- document that key-prefix mismatches are rejected before live payment paths run

## Why

Issue #88 calls out Stage 1 safety guards now that live payments are enabled. The webhook path already rejects `event.livemode` mismatches; this closes the matching secret-key side so a test key cannot run in live mode and a live key cannot run in test mode.

## Validation

- `git diff --check`
- `PATH=/Users/sravansridhar/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npx -y deno-bin test --allow-env supabase/functions/tests/stripe-config-test.ts`
- `PATH=/Users/sravansridhar/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npx -y deno-bin test --allow-env 'supabase/functions/tests/*.ts'` (45 passed, 0 failed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Stripe configuration guidance about environment mode validation and webhook livemode checks.

* **New Features**
  * Added startup validation to ensure Stripe secret keys match the configured environment (test vs live), surfacing clear errors for mismatches.

* **Tests**
  * Added coverage verifying mode detection, validation behavior, and enforcement during client creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->